### PR TITLE
chore: add auto assign

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @froggy1014 @azure-553 @ProdMoon @frontman-git @saseungmin @danmin20 @tara-JSW @joel-jo-querypie @jiji-hoon96 @KimHunJin @hy57in @synuns @sudosubin

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,9 @@
+addReviewers: true
+addAssignees: true
+
+reviewers:
+  - azure-553
+  - ProdMoon
+  - froggy1014
+  - frontman-git
+


### PR DESCRIPTION
## Description

<img width="689" alt="image" src="https://github.com/user-attachments/assets/6de0252a-cb23-4c96-a549-d1a90e760908" />

- [Auto_Assign Config](https://github.com/kentaro-m/auto-assign?tab=readme-ov-file#usage)

Review, Assignees 자동으로 등록해주기 위해서 auto_assign github app 등록 및 config 파일 추가했습니다.