### PR TITLE
fix: pass color to typhography with prop

### DIFF
--- a/src/components/molecules/Table/index.module.scss
+++ b/src/components/molecules/Table/index.module.scss
@@ -43,6 +43,3 @@
   }
 }
 
-.subText {
-  color: color('gray700');
-}

--- a/src/components/molecules/Table/index.tsx
+++ b/src/components/molecules/Table/index.tsx
@@ -60,7 +60,7 @@ function TableData({ data, isApplicant }: TableDataProps) {
       {isApplicant ? (
         <CheckCircleIcon />
       ) : (
-        <Typography className={styles.subText} size={14}>
+        <Typography color={color.gray400} size={14}>
           {data.recurring_date}
         </Typography>
       )}

--- a/src/components/molecules/accordion/AccordionItem/index.module.scss
+++ b/src/components/molecules/accordion/AccordionItem/index.module.scss
@@ -53,7 +53,6 @@
 .value {
   margin-top: 12px;
   border-radius: 8px;
-  color: color('gray700');
   background-color: color('gray100');
   padding: 12px 16px;
 

--- a/src/components/molecules/accordion/AccordionItem/index.tsx
+++ b/src/components/molecules/accordion/AccordionItem/index.tsx
@@ -50,7 +50,12 @@ function AccordionItem({
             exit={{ height: 0 }}
             transition={{ type: 'spring', duration: 0.4, bounce: 0 }}
           >
-            <Typography className={styles.value} size={14} weight="semiBold">
+            <Typography
+              color={color.gray200}
+              className={styles.value}
+              size={14}
+              weight="semiBold"
+            >
               {value}
             </Typography>
           </motion.div>

--- a/src/components/organisms/recruit/ScheduleCard/index.module.scss
+++ b/src/components/organisms/recruit/ScheduleCard/index.module.scss
@@ -19,7 +19,6 @@
   border-radius: 8px;
   flex: 1 1 0;
   text-align: center;
-  color: color('primary');
   font-size: 15px;
   line-height: 21px;
   letter-spacing: 0.3px;
@@ -29,7 +28,6 @@
 .subTitle {
   align-self: stretch;
   text-align: center;
-  color: color('gray700');
   line-height: 19.6px;
   word-wrap: break-word;
 }

--- a/src/components/organisms/recruit/ScheduleCard/index.tsx
+++ b/src/components/organisms/recruit/ScheduleCard/index.tsx
@@ -29,15 +29,20 @@ function ScheduleCard({ title, processDate, subTitle }: ScheduleCardProps) {
         >
           {title}
         </Typography>
-        <Flex
-          asChild={true}
-          align="center"
-          className={styles.highlightTitle}
-          justify="center"
-        >
-          <Typography weight="semiBold">{processDate}</Typography>
+        <Flex asChild={true} align="center" justify="center">
+          <Typography
+            className={styles.highlightTitle}
+            color={color.cyan400}
+            weight="semiBold"
+          >
+            {processDate}
+          </Typography>
         </Flex>
-        <Typography className={styles.subTitle} weight="medium">
+        <Typography
+          color={color.gray400}
+          className={styles.subTitle}
+          weight="medium"
+        >
           {subTitle}
         </Typography>
       </CardWrapper>


### PR DESCRIPTION
|AS-IS|TO-BE|
|:-:|:-:|
|<img width="263" alt="image" src="https://github.com/user-attachments/assets/cacd8327-9bbe-4105-8f44-b0b31cce0031" />|<img width="206" alt="image" src="https://github.com/user-attachments/assets/f17d4631-c74c-4ba9-b05c-5726ba65ec31" />|

현재 `Typography` 컴포넌트는 색상을 명시적으로 `color` 프롭스로 받고 있어서, classname을 통해서 들어오는 color에 대해서 무시하게 되고 있었습니다.