### PR TITLE
fix: 이미지 변경 시 새로 렌더링 되도록 수정

### DIFF
--- a/.script/gSheet.js
+++ b/.script/gSheet.js
@@ -188,7 +188,7 @@ function processPeopleData(peoplesRow, config) {
     const row = it['_rawData'];
 
     const thumbnailId = (row[12] ?? '').match(/\/d\/(.*?)\/view/)?.[1] ?? '';
-    const key = row[0] ?? Math.random().toString(36).substring(2, 15);
+    const key = row[0] || Math.random().toString(36).substring(2, 15);
     const period = row[4];
 
     periodsMap[period].push({

--- a/src/components/molecules/GlowArea/index.tsx
+++ b/src/components/molecules/GlowArea/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { PropsWithChildren } from 'react';
+import { CSSProperties, PropsWithChildren } from 'react';
 
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion, TargetAndTransition } from 'framer-motion';
 
 import useElementSize from '@/hook/useElementSize';
 import { createSVGMask } from '@/libs/utils/svg';
@@ -21,7 +21,9 @@ function GlowArea({ rx, children }: PropsWithChildren<GlowAreaProps>) {
       <div style={{ position: 'relative' }}>
         <motion.div
           className={styles.border}
-          animate={{ '--border-angle': ['0turn', '1turn'] } as any}
+          animate={
+            { '--border-angle': ['0turn', '1turn'] } as TargetAndTransition
+          }
           transition={{
             repeat: Infinity,
             duration: 6,
@@ -33,7 +35,7 @@ function GlowArea({ rx, children }: PropsWithChildren<GlowAreaProps>) {
               '--area-width': `${width}px`,
               '--area-height': `${height}px`,
               '--svg-mask': `url(${createSVGMask(width + 1, height + 1, rx)})`,
-            } as any
+            } as CSSProperties
           }
         ></motion.div>
         <div className={styles.area} ref={ref}>

--- a/src/components/molecules/Image/index.tsx
+++ b/src/components/molecules/Image/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CSSProperties, ReactNode, useCallback } from 'react';
 
 import NextImage, { ImageProps as NextImageProps } from 'next/image';
@@ -49,37 +51,28 @@ function Image({
     [fill, width, height, className],
   );
 
-  if (!src) {
-    return (
-      <>
-        {renderFillImage(
-          <NextImage
-            src={'/assets/empty_image.png'}
-            className={defaultClassName}
-            alt="기본 이미지"
-            fill={fill}
-            sizes={defaultSizes}
-            width={fill ? undefined : width}
-            height={fill ? undefined : height}
-            {...rest}
-          />,
-        )}
-      </>
-    );
-  }
+  const fallbackImageSource = '/assets/empty_image.png';
+  const imageSrc = src || fallbackImageSource;
+  const imageAlt = alt || 'Siper Image';
 
   return (
     <>
       {renderFillImage(
         <NextImage
-          key={src}
-          src={src}
-          alt={alt}
+          key={imageSrc}
+          src={imageSrc}
+          alt={imageAlt}
           className={defaultClassName}
           fill={fill}
           sizes={defaultSizes}
           width={fill ? undefined : width}
           height={fill ? undefined : height}
+          onError={(e) => {
+            const target = e.target as HTMLImageElement;
+            if (target.src !== fallbackImageSource) {
+              target.src = fallbackImageSource;
+            }
+          }}
           {...rest}
         />,
       )}

--- a/src/components/molecules/Image/index.tsx
+++ b/src/components/molecules/Image/index.tsx
@@ -72,6 +72,7 @@ function Image({
     <>
       {renderFillImage(
         <NextImage
+          key={src}
           src={src}
           alt={alt}
           className={defaultClassName}

--- a/src/components/molecules/Image/index.tsx
+++ b/src/components/molecules/Image/index.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode, useCallback } from 'react';
+import { CSSProperties, ReactNode, useCallback } from 'react';
 
 import NextImage, { ImageProps as NextImageProps } from 'next/image';
 

--- a/src/libs/utils/tick.ts
+++ b/src/libs/utils/tick.ts
@@ -5,14 +5,14 @@ export const debounce = <T extends (...args: unknown[]) => unknown>(
   let timer: ReturnType<typeof setTimeout>;
 
   return (...args: Parameters<T>): ReturnType<T> => {
-    let result: any;
+    let result;
     if (timer) {
       clearTimeout(timer);
     }
     timer = setTimeout(() => {
       result = func(...args);
     }, delay);
-    return result;
+    return result as ReturnType<T>;
   };
 };
 


### PR DESCRIPTION
## 변경 사항

### 스크립트 수정

기존에는 사용자 데이터의 `id`를 결정할 때 `??`를 이용해서 `id`가 존재하지 않으면 무작위 문자열을 생성해 사용했었는데, `??`는 nullish coalescing operator로 값이 `null`이거나 `undefined` 일 떄에만 동작합니다. 실제로는 비어있는 셀에서는 빈 문자열이 응답으로 내려와 이 로직을 타지 않는 문제가 있었고, `||` operator로 변경했습니다.

참고로 현재는 사용자 데이터 시트에 `id` 셀을 추가하여 값을 추가해두어서 `id` 값이 잘 결정되고 있습니다.

<img alt="CleanShot 2025-04-24 at 20 39 49@2x" src="https://github.com/user-attachments/assets/076b072a-9b75-4cfd-8584-0f95792f077d" width="300px" />

### 이미지 렌더링 수정

Image의 `src`가 변경될 때, 새로운 이미지를 완전히 로드하기 전까지 이미지가 유지되다가 뒤늦게 변경되는 현상이 있었습니다.

`key` 값을 `src`와 동일하게 넣어서 reconciliation에 따라서 다시 즉시 렌더링 되고, 그 과정에서 기존 이미지가 계속 유지되지 않도록 수정했습니다.

| as-is | to-be |
| - | - |
| <video src="https://github.com/user-attachments/assets/b24a7ba2-d82b-4b1c-9e66-28005923ff98" /> | <video src="https://github.com/user-attachments/assets/ba8a644e-1739-428d-9c4c-7a6fdf10f35d" /> |
