### PR TITLE
feat: SIPE 블로그 버튼 추가

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
     }
   ],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "prettier.prettierPath": ".yarn/sdks/prettier/index.cjs",
   "typescript.tsdk": ".yarn/sdks/typescript/lib",

--- a/src/components/global/Navigation/index.tsx
+++ b/src/components/global/Navigation/index.tsx
@@ -84,13 +84,14 @@ function Navigation() {
                     buttonType="menu"
                     active={menu.path === pathname}
                     href={menu.path}
+                    isExternalLink={menu.isExternal}
                   >
                     {menu.name}
                   </Button>
                 ))}
                 <Button
                   disabled={currentStatus !== 'ongoing'}
-                  isExternalLink={true}
+                  isExternalLink
                   href={currentApplicationDetail.formUrl}
                   buttonType="apply"
                   onClick={handleClickJoinUsButton}

--- a/src/components/global/Navigation/index.tsx
+++ b/src/components/global/Navigation/index.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 
-import { Route } from 'next';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
@@ -18,11 +17,12 @@ import { displayApplication, getCurrentStatus } from '@/libs/utils/recruit';
 
 import styles from './index.module.scss';
 
-const menus: { name: string; path: Route }[] = [
+const menus: { name: string; path: string; isExternal?: boolean }[] = [
   { name: 'About', path: '/about' },
   { name: 'Recruit', path: '/recruit' },
   { name: 'People', path: '/people' },
   { name: 'Activity', path: '/activity' },
+  { name: 'Blog', path: 'https://blog.sipe.team', isExternal: true },
 ];
 
 function Navigation() {
@@ -90,7 +90,7 @@ function Navigation() {
                 ))}
                 <Button
                   disabled={currentStatus !== 'ongoing'}
-                  isExternalLink
+                  isExternalLink={true}
                   href={currentApplicationDetail.formUrl}
                   buttonType="apply"
                   onClick={handleClickJoinUsButton}


### PR DESCRIPTION
# 변경사항
- SIPE 블로그로 접속되는 버튼과 외부 링크를 추가했습니다.

# 스크린샷

AS-IS | TO-BE
-- | --
<img width="1440" alt="Screenshot 2025-07-01 at 18 19 38" src="https://github.com/user-attachments/assets/73211944-01c6-44cb-ae4d-d3bdf80f8050" />  |  <img width="1440" alt="Screenshot 2025-07-01 at 18 21 34" src="https://github.com/user-attachments/assets/268ba8dc-773f-47ed-bb0e-97460c63dcde" />

AS-IS | TO-BE
-- | --
<img width="355" alt="Screenshot 2025-07-01 at 18 20 11" src="https://github.com/user-attachments/assets/eccc97b7-4bc8-4bef-83c1-f99728a19fe6" /> | <img width="354" alt="Screenshot 2025-07-01 at 18 21 52" src="https://github.com/user-attachments/assets/f7be7e33-a966-4398-8e87-a02de697bc31" />




