### PR TITLE
fix: 하이라이팅된 콘텐츠만 모바일에서 fill 차지하지 않는 버그 해결(#177)

### DIFF
--- a/src/components/molecules/Table/index.module.scss
+++ b/src/components/molecules/Table/index.module.scss
@@ -4,6 +4,10 @@
 
   @include mobile {
     gap: 16px;
+
+    > * {
+      width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
## Fix: 모바일에서 하이라이팅된 콘텐츠의 fill 미적용 버그 해결

### 이슈 해결
#177 이슈를 해결합니다.

### 작업 내용
- 모바일 환경에서 하이라이팅된 콘텐츠가 부모 영역의 전체 너비를 100%로 차지하지 않던 문제를 수정했습니다.
- 하이라이팅 영역의 레이아웃 스타일을 모바일 기준으로 보완하여, 의도한 영역만큼 안정적으로 렌더링되도록 개선했습니다.

---

### 변경 전 / 변경 후

| As-Is | To-Be |
| :---: | :---: |
| 모바일에서 하이라이팅된 콘텐츠가 영역을 다 채우지 못함 | 모바일에서도 하이라이팅된 콘텐츠가 부모 영역을 정상적으로 fill |
| <img src="https://github.com/user-attachments/assets/537a47b1-d892-4904-9d93-2ed96f1ece51" width="300" /> | ![after](https://github.com/user-attachments/assets/9b073275-134a-4148-a2be-c861a6a9edd2) |

---

### 확인 사항
- [x] 모바일 환경에서 하이라이팅 영역 정상 렌더링 확인
- [x] 기존 데스크탑 레이아웃 영향 없는지 확인
- [x] 반응형 UI 동작 확인