### PR TITLE
fix: 홈페이지 콘텐츠 텍스트들이 단어로 깨지는 것이 아니라 글자간으로 깨지게 되는 이슈를 해결한다. (#179)

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -5,6 +5,7 @@
 * {
   box-sizing: border-box;
   appearance: none;
+  word-break: keep-all;
 }
 
 a {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -6,6 +6,7 @@
   box-sizing: border-box;
   appearance: none;
   word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 a {


### PR DESCRIPTION
## Fix: 홈페이지 콘텐츠 텍스트들이 단어로 깨지는 것이 아니라 글자간으로 깨지게 되는 이슈를 해결

### 이슈 해결
#179  이슈를 해결합니다.

### 작업 내용
- 콘텐츠 텍스트들이 단어로 깨지는 것이 아니라 글자간으로 깨지게 되어서 가독성이 떨어집니다.

---

### 변경 전 / 변경 후

| As-Is | To-Be |
| :---: | :---: |
| 단어 한글자씩 깨지며 줄바꿈됨 | 단어 글자마다 깨지지 않도록 개선 |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/f8ed56f4-78d6-46f1-8784-15838cc28fb8" /> | <img width="286" height="215" alt="image" src="https://github.com/user-attachments/assets/abcf55a0-505e-48fc-bf38-911912240d40" /> |

---

### 확인 사항
- [x] 전 텍스트 단어깨짐 되지 않도록 체크
- [x] 전역 스타일(global.css)에 적용