### PR TITLE
fix: 아코디언 타이틀에 들어간 고정 높이값을 최소 조건으로 유연하게 변경(#180)

### DIFF
--- a/src/components/molecules/accordion/AccordionItem/index.module.scss
+++ b/src/components/molecules/accordion/AccordionItem/index.module.scss
@@ -15,14 +15,14 @@
 
 .title {
   cursor: pointer;
-  height: 36px;
+  min-height: 36px;
   text-align: left;
   padding: 0 0 0 12px;
   box-sizing: border-box;
   user-select: none;
 
   @include desktop {
-    height: 48px;
+    min-height: 48px;
     font-size: 17px;
     line-height: 24px;
     padding: 0 20px;


### PR DESCRIPTION
## Fix: 아코디언 타이틀에 들어간 고정 높이값을 최소 조건으로 유연하게 변경

### 이슈 해결
#180  이슈를 해결합니다.

### 작업 내용
- 아코디언의 타이틀에 해당하는 콘텐츠가 길 경우, 위 아래 padding을 넘어서 줄바꿈되어 UI가 어색해지는 문제를 해결한다.
---

### 변경 전 / 변경 후

| As-Is | To-Be |
| :---: | :---: |
| 타이틀에 해당하는 콘텐츠가 길때 어색해짐 | 고정값 높이로 인해 발생한 일로 min수치로 적용 |
| <img width="197" height="111" alt="image" src="https://github.com/user-attachments/assets/c113b419-a7f3-4d14-bfce-acc1a7c568a3" /> | <img width="185" height="389" alt="image" src="https://github.com/user-attachments/assets/002fe799-aa5b-4146-9b8a-43ab490ca838" /> |

---

### 확인 사항
- [x] 아코디언 타이틀이 깨지는 원인 현상 파악 -> 고정높이값으로 들어가있었음
- [x] 고정 높이값을 -> min-height로 유연하게 변경