### PR TITLE
refactor: side Flex 마이그레이션을 위한 테스트 추가 및 1유형 wrapper 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ dist-ssr
 
 # Zero Install: https://yarnpkg.com/features/zero-installs
 .yarn/*
-!.yarn/cache
+# local dependency cache
+.yarn/cache
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev": "next dev -p 6100 & yarn open-browser",
     "build": "yarn run script && next build",
     "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint:prettier": "prettier . --write",
     "lint:eslint": "eslint . --fix",
     "script": "node .script/gSheet.js"
@@ -33,6 +35,9 @@
     "@next/eslint-plugin-next": "^15.2.4",
     "@playwright/test": "^1.49.1",
     "@svgr/webpack": "8.1.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^20.12.2",
     "@types/react": "^18.3.4",
     "@types/react-dom": "^18.3.0",
@@ -50,11 +55,13 @@
     "google-auth-library": "^9.14.0",
     "google-spreadsheet": "^4.1.2",
     "husky": "^9.1.7",
+    "jsdom": "^26.1.0",
     "lint-staged": "^15.5.0",
     "prettier": "^3.3.3",
     "sass": "1.77.8",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.28.0",
+    "vitest": "^3.2.4",
     "webpack": "5.93.0"
   },
   "lint-staged": {

--- a/src/components/molecules/Card/index.module.scss
+++ b/src/components/molecules/Card/index.module.scss
@@ -1,12 +1,6 @@
 .section {
   width: 100%;
-  display: flex;
-  flex: 1 1;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: 24px;
   margin-bottom: 60px;
-  flex-direction: column;
 
   &:last-of-type {
     margin-bottom: 0;
@@ -51,13 +45,8 @@
 .titleWrapper {
   padding: 8px 0;
   margin-top: 24px;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: 24px;
   width: auto;
   min-height: 270px;
-  display: inline-flex;
   box-shadow: '0px 4px 4px rgba(0, 0, 0, 0.25)';
   border: '1px black solid';
 

--- a/src/components/molecules/Card/index.test.tsx
+++ b/src/components/molecules/Card/index.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+
+import Card from './index';
+
+vi.mock('@/components/atoms/Badge', () => ({
+  default: ({ text }: { text: string }) => <div data-testid="badge">{text}</div>,
+}));
+
+vi.mock('@/components/molecules/Image', () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => <img alt={alt} src={src} />,
+}));
+
+describe('Card', () => {
+  it('renders the badge, image, title, and subtitle', () => {
+    render(
+      <Card
+        src="/card.png"
+        badgeText="후원사"
+        title="카드 제목"
+        subTitle="카드 설명"
+      />,
+    );
+
+    expect(screen.getByTestId('badge')).toHaveTextContent('후원사');
+    expect(screen.getByAltText('카드 제목')).toBeInTheDocument();
+    expect(screen.getByText('카드 제목')).toBeInTheDocument();
+    expect(screen.getByText('카드 설명')).toBeInTheDocument();
+  });
+});

--- a/src/components/molecules/Card/index.test.tsx
+++ b/src/components/molecules/Card/index.test.tsx
@@ -3,11 +3,17 @@ import { render, screen } from '@testing-library/react';
 import Card from './index';
 
 vi.mock('@/components/atoms/Badge', () => ({
-  default: ({ text }: { text: string }) => <div data-testid="badge">{text}</div>,
+  default: ({ text }: { text: string }) => (
+    <div data-testid="badge">{text}</div>
+  ),
 }));
 
 vi.mock('@/components/molecules/Image', () => ({
-  default: ({ alt, src }: { alt: string; src: string }) => <img alt={alt} src={src} />,
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    // Tests only need an element with alt text semantics.
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src={src} />
+  ),
 }));
 
 describe('Card', () => {

--- a/src/components/molecules/Card/index.tsx
+++ b/src/components/molecules/Card/index.tsx
@@ -34,7 +34,14 @@ function Card({ src, badgeText, title, subTitle, reverse }: CardProps) {
         height={270}
         objectFit="contain"
       />
-      <Flex align="flex-start" className={styles.titleWrapper} direction="column" gap="24px" inline={true} justify="flex-start">
+      <Flex
+        align="flex-start"
+        className={styles.titleWrapper}
+        direction="column"
+        gap="24px"
+        inline={true}
+        justify="flex-start"
+      >
         <Badge text={badgeText} />
         <div className={styles.title}>{title}</div>
         <div className={styles.subTitle}>{subTitle}</div>

--- a/src/components/molecules/Card/index.tsx
+++ b/src/components/molecules/Card/index.tsx
@@ -1,3 +1,4 @@
+import { Flex } from '@sipe-team/side';
 import clsx from 'clsx';
 
 import Badge from '@/components/atoms/Badge';
@@ -15,7 +16,15 @@ interface CardProps {
 
 function Card({ src, badgeText, title, subTitle, reverse }: CardProps) {
   return (
-    <div className={clsx(styles.section, reverse && styles.reverse)}>
+    <Flex
+      align="flex-start"
+      className={clsx(styles.section, reverse && styles.reverse)}
+      direction="column"
+      gap="24px"
+      grow={1}
+      justify="flex-start"
+      shrink={1}
+    >
       <Image
         fill
         priority
@@ -25,12 +34,12 @@ function Card({ src, badgeText, title, subTitle, reverse }: CardProps) {
         height={270}
         objectFit="contain"
       />
-      <div className={styles.titleWrapper}>
+      <Flex align="flex-start" className={styles.titleWrapper} direction="column" gap="24px" inline={true} justify="flex-start">
         <Badge text={badgeText} />
         <div className={styles.title}>{title}</div>
         <div className={styles.subTitle}>{subTitle}</div>
-      </div>
-    </div>
+      </Flex>
+    </Flex>
   );
 }
 

--- a/src/components/organisms/about/ActivitiesSection/index.module.scss
+++ b/src/components/organisms/about/ActivitiesSection/index.module.scss
@@ -1,11 +1,6 @@
 .description {
   width: 100%;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
   margin-top: 48px;
-  gap: 16px;
-  display: inline-flex;
   margin-bottom: 40px;
 
   .title {
@@ -56,7 +51,6 @@
 }
 
 .menus {
-  display: flex;
   justify-content: center;
   gap: 16px;
   margin-bottom: 40px;

--- a/src/components/organisms/about/ActivitiesSection/index.test.tsx
+++ b/src/components/organisms/about/ActivitiesSection/index.test.tsx
@@ -1,0 +1,91 @@
+import type { ReactNode } from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import ActivitiesSection from './index';
+
+vi.mock('swiper/modules', () => ({
+  Autoplay: {},
+  EffectCoverflow: {},
+  Pagination: {},
+}));
+
+vi.mock('swiper/react', () => ({
+  Swiper: ({ children }: { children: ReactNode }) => <div data-testid="swiper">{children}</div>,
+  SwiperSlide: ({ children }: { children: ({ isActive }: { isActive: boolean }) => ReactNode }) => (
+    <div data-testid="swiper-slide">{children({ isActive: true })}</div>
+  ),
+}));
+
+vi.mock('@/components/atoms/ContentWithTitle', () => ({
+  default: ({ children, title }: { children: ReactNode; title: string }) => (
+    <section data-testid="content-with-title">
+      <h1>{title}</h1>
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('@/components/molecules/Button', () => ({
+  default: ({
+    children,
+    onClick,
+    active,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    active?: boolean;
+  }) => (
+    <button aria-pressed={active} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/molecules/Image', () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => <img alt={alt} src={src} />,
+}));
+
+vi.mock('@/db', () => ({
+  getAbout: () => ({
+    activity: {
+      session: {
+        key: 'session',
+        name: '세션',
+        title: '세션 활동',
+        description: '세션 설명',
+        activities: ['/session-1.png', '/session-2.png'],
+      },
+      networking: {
+        key: 'networking',
+        name: '네트워킹',
+        title: '네트워킹 활동',
+        description: '네트워킹 설명',
+        activities: ['/networking-1.png'],
+      },
+    },
+  }),
+}));
+
+describe('ActivitiesSection', () => {
+  it('renders the initially selected activity menu and description', () => {
+    render(<ActivitiesSection />);
+
+    expect(screen.getByText('주요 활동')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '세션' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '네트워킹' })).toBeInTheDocument();
+    expect(screen.getByText('세션 활동')).toBeInTheDocument();
+    expect(screen.getByText('세션 설명')).toBeInTheDocument();
+    expect(screen.getAllByAltText('activity')).toHaveLength(2);
+  });
+
+  it('updates the description when another activity menu is selected', () => {
+    render(<ActivitiesSection />);
+
+    fireEvent.click(screen.getByRole('button', { name: '네트워킹' }));
+
+    expect(screen.getByText('네트워킹 활동')).toBeInTheDocument();
+    expect(screen.getByText('네트워킹 설명')).toBeInTheDocument();
+    expect(screen.getAllByAltText('activity')).toHaveLength(1);
+  });
+});

--- a/src/components/organisms/about/ActivitiesSection/index.test.tsx
+++ b/src/components/organisms/about/ActivitiesSection/index.test.tsx
@@ -11,10 +11,14 @@ vi.mock('swiper/modules', () => ({
 }));
 
 vi.mock('swiper/react', () => ({
-  Swiper: ({ children }: { children: ReactNode }) => <div data-testid="swiper">{children}</div>,
-  SwiperSlide: ({ children }: { children: ({ isActive }: { isActive: boolean }) => ReactNode }) => (
-    <div data-testid="swiper-slide">{children({ isActive: true })}</div>
+  Swiper: ({ children }: { children: ReactNode }) => (
+    <div data-testid="swiper">{children}</div>
   ),
+  SwiperSlide: ({
+    children,
+  }: {
+    children: ({ isActive }: { isActive: boolean }) => ReactNode;
+  }) => <div data-testid="swiper-slide">{children({ isActive: true })}</div>,
 }));
 
 vi.mock('@/components/atoms/ContentWithTitle', () => ({
@@ -43,7 +47,11 @@ vi.mock('@/components/molecules/Button', () => ({
 }));
 
 vi.mock('@/components/molecules/Image', () => ({
-  default: ({ alt, src }: { alt: string; src: string }) => <img alt={alt} src={src} />,
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    // Tests only need an element with alt text semantics.
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src={src} />
+  ),
 }));
 
 vi.mock('@/db', () => ({
@@ -73,7 +81,9 @@ describe('ActivitiesSection', () => {
 
     expect(screen.getByText('주요 활동')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '세션' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '네트워킹' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: '네트워킹' }),
+    ).toBeInTheDocument();
     expect(screen.getByText('세션 활동')).toBeInTheDocument();
     expect(screen.getByText('세션 설명')).toBeInTheDocument();
     expect(screen.getAllByAltText('activity')).toHaveLength(2);

--- a/src/components/organisms/about/ActivitiesSection/index.tsx
+++ b/src/components/organisms/about/ActivitiesSection/index.tsx
@@ -9,6 +9,8 @@ import clsx from 'clsx';
 import { Autoplay, EffectCoverflow, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
+import { Flex } from '@sipe-team/side';
+
 import ContentWithTitle from '@/components/atoms/ContentWithTitle';
 import Button from '@/components/molecules/Button';
 import Image from '@/components/molecules/Image';
@@ -30,7 +32,7 @@ function ActivitiesSection() {
 
   return (
     <ContentWithTitle title="주요 활동">
-      <div className={styles.menus}>
+      <Flex className={styles.menus}>
         {activities.map(([key, activity]) => (
           <Button
             className={styles.activityButton}
@@ -42,7 +44,7 @@ function ActivitiesSection() {
             {activity.name}
           </Button>
         ))}
-      </div>
+      </Flex>
       <Swiper
         loop={activityData.activities.length > 1 ? true : false}
         className={styles.swiper}
@@ -86,10 +88,10 @@ function ActivitiesSection() {
           </SwiperSlide>
         ))}
       </Swiper>
-      <div className={styles.description}>
+      <Flex align="center" className={styles.description} direction="column" gap="16px" inline={true} justify="center">
         <div className={styles.title}>{activityData?.title}</div>
         <div className={styles.subTitle}>{activityData?.description}</div>
-      </div>
+      </Flex>
     </ContentWithTitle>
   );
 }

--- a/src/components/organisms/about/ActivitiesSection/index.tsx
+++ b/src/components/organisms/about/ActivitiesSection/index.tsx
@@ -3,13 +3,12 @@
 import 'swiper/css/bundle';
 import 'swiper/css/pagination';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
+import { Flex } from '@sipe-team/side';
 import clsx from 'clsx';
 import { Autoplay, EffectCoverflow, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
-
-import { Flex } from '@sipe-team/side';
 
 import ContentWithTitle from '@/components/atoms/ContentWithTitle';
 import Button from '@/components/molecules/Button';
@@ -24,11 +23,7 @@ function ActivitiesSection() {
   const activities = getEntries(activity);
 
   const [selectChip, setSelectChip] = useState<string>(activities[0][1].key);
-  const [activityData, setActivityData] = useState(activity[selectChip]);
-
-  useEffect(() => {
-    setActivityData(activity[selectChip]);
-  }, [selectChip]);
+  const activityData = activity[selectChip];
 
   return (
     <ContentWithTitle title="주요 활동">
@@ -88,7 +83,14 @@ function ActivitiesSection() {
           </SwiperSlide>
         ))}
       </Swiper>
-      <Flex align="center" className={styles.description} direction="column" gap="16px" inline={true} justify="center">
+      <Flex
+        align="center"
+        className={styles.description}
+        direction="column"
+        gap="16px"
+        inline={true}
+        justify="center"
+      >
         <div className={styles.title}>{activityData?.title}</div>
         <div className={styles.subTitle}>{activityData?.description}</div>
       </Flex>

--- a/src/components/organisms/home/RecruitmentSummarySkeleton/index.module.scss
+++ b/src/components/organisms/home/RecruitmentSummarySkeleton/index.module.scss
@@ -1,9 +1,4 @@
 .timerWrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-
   .timerDescription {
     font-size: 1.4rem;
     font-weight: 500;

--- a/src/components/organisms/home/RecruitmentSummarySkeleton/index.test.tsx
+++ b/src/components/organisms/home/RecruitmentSummarySkeleton/index.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+
+import RecruitmentSummary from './index';
+
+vi.mock('@/components/atoms/Timer', () => ({
+  default: () => <div data-testid="timer">timer</div>,
+}));
+
+vi.mock('@/components/organisms/home/SummaryCards', () => ({
+  default: () => <div data-testid="summary-cards">summary cards</div>,
+}));
+
+describe('RecruitmentSummarySkeleton', () => {
+  it('renders the start countdown message and timer in before status', () => {
+    render(<RecruitmentSummary currentStatus="before" />);
+
+    expect(screen.getByText('모집 시작까지')).toBeInTheDocument();
+    expect(screen.getByTestId('timer')).toBeInTheDocument();
+  });
+
+  it('renders the end countdown message and timer in ongoing status', () => {
+    render(<RecruitmentSummary currentStatus="ongoing" />);
+
+    expect(screen.getByText('모집 마감까지')).toBeInTheDocument();
+    expect(screen.getByTestId('timer')).toBeInTheDocument();
+  });
+
+  it('renders summary cards in after status', () => {
+    render(<RecruitmentSummary currentStatus="after" />);
+
+    expect(screen.getByTestId('summary-cards')).toBeInTheDocument();
+    expect(screen.queryByTestId('timer')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/organisms/home/RecruitmentSummarySkeleton/index.tsx
+++ b/src/components/organisms/home/RecruitmentSummarySkeleton/index.tsx
@@ -1,3 +1,5 @@
+import { Flex } from '@sipe-team/side';
+
 import Timer from '@/components/atoms/Timer';
 import SummaryCard from '@/components/organisms/home/SummaryCards';
 
@@ -10,7 +12,7 @@ type Props = {
 function RecruitmentSummary({ currentStatus }: Props) {
   const elements = {
     before: () => (
-      <div className={styles.timerWrapper}>
+      <Flex align="center" className={styles.timerWrapper} direction="column" gap="1rem">
         <div className={styles.timerDescription}>모집 시작까지</div>
         <Timer
           dates={0}
@@ -19,10 +21,10 @@ function RecruitmentSummary({ currentStatus }: Props) {
           seconds={0}
           isRecruiting={false}
         />
-      </div>
+      </Flex>
     ),
     ongoing: () => (
-      <div className={styles.timerWrapper}>
+      <Flex align="center" className={styles.timerWrapper} direction="column" gap="1rem">
         <div className={styles.timerDescription}>모집 마감까지</div>
         <Timer
           dates={0}
@@ -31,7 +33,7 @@ function RecruitmentSummary({ currentStatus }: Props) {
           seconds={0}
           isRecruiting={false}
         />
-      </div>
+      </Flex>
     ),
     after: () => <SummaryCard />,
   };

--- a/src/components/organisms/home/RecruitmentSummarySkeleton/index.tsx
+++ b/src/components/organisms/home/RecruitmentSummarySkeleton/index.tsx
@@ -12,7 +12,12 @@ type Props = {
 function RecruitmentSummary({ currentStatus }: Props) {
   const elements = {
     before: () => (
-      <Flex align="center" className={styles.timerWrapper} direction="column" gap="1rem">
+      <Flex
+        align="center"
+        className={styles.timerWrapper}
+        direction="column"
+        gap="1rem"
+      >
         <div className={styles.timerDescription}>모집 시작까지</div>
         <Timer
           dates={0}
@@ -24,7 +29,12 @@ function RecruitmentSummary({ currentStatus }: Props) {
       </Flex>
     ),
     ongoing: () => (
-      <Flex align="center" className={styles.timerWrapper} direction="column" gap="1rem">
+      <Flex
+        align="center"
+        className={styles.timerWrapper}
+        direction="column"
+        gap="1rem"
+      >
         <div className={styles.timerDescription}>모집 마감까지</div>
         <Timer
           dates={0}

--- a/src/components/organisms/recruit/RecruitBarChart/index.module.scss
+++ b/src/components/organisms/recruit/RecruitBarChart/index.module.scss
@@ -1,8 +1,5 @@
 .wrapper {
   width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
   padding: 20px;
   border-radius: 12px;
   background-color: color('gray000');
@@ -50,9 +47,6 @@
 }
 
 .barWrapper {
-  display: flex;
-  align-items: center;
-  gap: 10px;
   position: relative;
 }
 

--- a/src/components/organisms/recruit/RecruitBarChart/index.test.tsx
+++ b/src/components/organisms/recruit/RecruitBarChart/index.test.tsx
@@ -19,16 +19,32 @@ describe('RecruitBarChart', () => {
       <RecruitBarChart
         title="지원 현황"
         data={[
-          { name: 'Backend', value: 10, percentage: 50, examples: 'Java, Kotlin' },
-          { name: 'Frontend', value: 10, percentage: 50, examples: 'React, Next.js' },
+          {
+            name: 'Backend',
+            value: 10,
+            percentage: 50,
+            examples: 'Java, Kotlin',
+          },
+          {
+            name: 'Frontend',
+            value: 10,
+            percentage: 50,
+            examples: 'React, Next.js',
+          },
         ]}
       />,
     );
 
-    expect(screen.getByRole('region', { name: '지원 현황 차트' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('region', { name: '지원 현황 차트' }),
+    ).toBeInTheDocument();
     expect(screen.getByText('지원 현황')).toBeInTheDocument();
-    expect(screen.getByLabelText('Backend: 10명, 50퍼센트')).toBeInTheDocument();
-    expect(screen.getByLabelText('Frontend: 10명, 50퍼센트')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Backend: 10명, 50퍼센트'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Frontend: 10명, 50퍼센트'),
+    ).toBeInTheDocument();
     expect(screen.getAllByText('10명')).toHaveLength(2);
   });
 });

--- a/src/components/organisms/recruit/RecruitBarChart/index.test.tsx
+++ b/src/components/organisms/recruit/RecruitBarChart/index.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+
+import RecruitBarChart from './index';
+
+vi.mock('@/hooks/useIntersectionObserver', () => ({
+  useIntersectionObserver: () => ({
+    ref: vi.fn(),
+    isVisible: true,
+  }),
+}));
+
+vi.mock('@/hooks/useCountAnimation', () => ({
+  useCountAnimation: ({ end }: { end: number }) => end,
+}));
+
+describe('RecruitBarChart', () => {
+  it('renders the chart title and each bar item', () => {
+    render(
+      <RecruitBarChart
+        title="지원 현황"
+        data={[
+          { name: 'Backend', value: 10, percentage: 50, examples: 'Java, Kotlin' },
+          { name: 'Frontend', value: 10, percentage: 50, examples: 'React, Next.js' },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('region', { name: '지원 현황 차트' })).toBeInTheDocument();
+    expect(screen.getByText('지원 현황')).toBeInTheDocument();
+    expect(screen.getByLabelText('Backend: 10명, 50퍼센트')).toBeInTheDocument();
+    expect(screen.getByLabelText('Frontend: 10명, 50퍼센트')).toBeInTheDocument();
+    expect(screen.getAllByText('10명')).toHaveLength(2);
+  });
+});

--- a/src/components/organisms/recruit/RecruitBarChart/index.tsx
+++ b/src/components/organisms/recruit/RecruitBarChart/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Flex } from '@sipe-team/side';
 import { useState } from 'react';
+
+import { Flex } from '@sipe-team/side';
 
 import { useCountAnimation } from '@/hooks/useCountAnimation';
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
@@ -124,26 +125,27 @@ function RecruitBarChart({
   return (
     <Flex asChild className={styles.wrapper} direction="column" gap="24px">
       <section aria-label={`${title} 차트`}>
-      <div className={styles.visuallyHidden}>
-        {title}: {data.map((item) => `${item.name} ${item.value}명`).join(', ')}
-      </div>
-      <div className={styles.titleWrapper}>
-        <h3 className={styles.title}>{title}</h3>
-      </div>
-      {data.map((item) => (
-        <BarItem
-          key={item.name}
-          item={item}
-          barColor={barColor}
-          barWidthMultiplier={barWidthMultiplier}
-          maxValue={maxValue}
-          onMouseEnter={() => setHoveredItem(item)}
-          onMouseLeave={() => setHoveredItem(null)}
-          onMouseMove={handleMouseMove}
-          isHovered={hoveredItem?.name === item.name}
-          mousePosition={mousePosition}
-        />
-      ))}
+        <div className={styles.visuallyHidden}>
+          {title}:{' '}
+          {data.map((item) => `${item.name} ${item.value}명`).join(', ')}
+        </div>
+        <div className={styles.titleWrapper}>
+          <h3 className={styles.title}>{title}</h3>
+        </div>
+        {data.map((item) => (
+          <BarItem
+            key={item.name}
+            item={item}
+            barColor={barColor}
+            barWidthMultiplier={barWidthMultiplier}
+            maxValue={maxValue}
+            onMouseEnter={() => setHoveredItem(item)}
+            onMouseLeave={() => setHoveredItem(null)}
+            onMouseMove={handleMouseMove}
+            isHovered={hoveredItem?.name === item.name}
+            mousePosition={mousePosition}
+          />
+        ))}
       </section>
     </Flex>
   );

--- a/src/components/organisms/recruit/RecruitBarChart/index.tsx
+++ b/src/components/organisms/recruit/RecruitBarChart/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Flex } from '@sipe-team/side';
 import { useState } from 'react';
 
 import { useCountAnimation } from '@/hooks/useCountAnimation';
@@ -69,7 +70,7 @@ function BarItem({
       onBlur={onMouseLeave}
     >
       <p className={styles.label}>{item.name}</p>
-      <div className={styles.barWrapper}>
+      <Flex align="center" className={styles.barWrapper} gap="10px">
         <div
           className={styles.bar}
           style={{
@@ -79,7 +80,7 @@ function BarItem({
           }}
         />
         <span className={styles.value}>{displayValue}명</span>
-      </div>
+      </Flex>
       {isHovered && (
         <div
           className={styles.tooltip}
@@ -121,7 +122,8 @@ function RecruitBarChart({
   };
 
   return (
-    <section className={styles.wrapper} aria-label={`${title} 차트`}>
+    <Flex asChild className={styles.wrapper} direction="column" gap="24px">
+      <section aria-label={`${title} 차트`}>
       <div className={styles.visuallyHidden}>
         {title}: {data.map((item) => `${item.name} ${item.value}명`).join(', ')}
       </div>
@@ -142,7 +144,8 @@ function RecruitBarChart({
           mousePosition={mousePosition}
         />
       ))}
-    </section>
+      </section>
+    </Flex>
   );
 }
 

--- a/src/components/pages/Activity/index.module.scss
+++ b/src/components/pages/Activity/index.module.scss
@@ -2,8 +2,6 @@
   width: 100%;
 
   .cards {
-    display: flex;
-    flex-direction: column;
     gap: 32px;
 
     .card {
@@ -29,7 +27,6 @@
 }
 
 .typeWrapper {
-  display: flex;
   margin-bottom: 40px;
   gap: 16px;
 

--- a/src/components/pages/Activity/index.test.tsx
+++ b/src/components/pages/Activity/index.test.tsx
@@ -7,7 +7,9 @@ import type { ActivityPost, ActivityVideo } from '@/db/model';
 import Activity from './index';
 
 vi.mock('@/components/atoms/Layout', () => ({
-  default: ({ children }: { children: ReactNode }) => <div data-testid="layout">{children}</div>,
+  default: ({ children }: { children: ReactNode }) => (
+    <div data-testid="layout">{children}</div>
+  ),
 }));
 
 vi.mock('@/components/atoms/ContentWithTitle', () => ({
@@ -20,17 +22,25 @@ vi.mock('@/components/atoms/ContentWithTitle', () => ({
 }));
 
 vi.mock('@/components/molecules/Button', () => ({
-  default: ({ children, active }: { children: ReactNode; active?: boolean }) => (
-    <button aria-pressed={active}>{children}</button>
-  ),
+  default: ({
+    children,
+    active,
+  }: {
+    children: ReactNode;
+    active?: boolean;
+  }) => <button aria-pressed={active}>{children}</button>,
 }));
 
 vi.mock('@/components/organisms/activity/ActiveCard', () => ({
-  default: ({ contentTitle }: { contentTitle: string }) => <article data-testid="active-card">{contentTitle}</article>,
+  default: ({ contentTitle }: { contentTitle: string }) => (
+    <article data-testid="active-card">{contentTitle}</article>
+  ),
 }));
 
 vi.mock('@/components/organisms/activity/ActiveVideoCard', () => ({
-  default: ({ contentTitle }: { contentTitle: string }) => <article data-testid="active-video-card">{contentTitle}</article>,
+  default: ({ contentTitle }: { contentTitle: string }) => (
+    <article data-testid="active-video-card">{contentTitle}</article>
+  ),
 }));
 
 const postActivities: ActivityPost[] = [
@@ -65,7 +75,9 @@ describe('Activity page', () => {
   it('renders blog cards in the post tab', () => {
     render(<Activity activityData={postActivities} currentTab="post" />);
 
-    expect(screen.getByRole('button', { name: '발표 영상' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: '발표 영상' }),
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '블로그' })).toBeInTheDocument();
     expect(screen.getAllByTestId('active-card')).toHaveLength(1);
     expect(screen.queryByTestId('active-video-card')).not.toBeInTheDocument();
@@ -77,6 +89,8 @@ describe('Activity page', () => {
 
     expect(screen.getAllByTestId('active-video-card')).toHaveLength(1);
     expect(screen.queryByTestId('active-card')).not.toBeInTheDocument();
-    expect(screen.getByTestId('active-video-card')).toHaveTextContent('발표 영상');
+    expect(screen.getByTestId('active-video-card')).toHaveTextContent(
+      '발표 영상',
+    );
   });
 });

--- a/src/components/pages/Activity/index.test.tsx
+++ b/src/components/pages/Activity/index.test.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import type { ActivityPost, ActivityVideo } from '@/db/model';
+
+import Activity from './index';
+
+vi.mock('@/components/atoms/Layout', () => ({
+  default: ({ children }: { children: ReactNode }) => <div data-testid="layout">{children}</div>,
+}));
+
+vi.mock('@/components/atoms/ContentWithTitle', () => ({
+  default: ({ children, title }: { children: ReactNode; title: string }) => (
+    <section data-testid="content-with-title">
+      <h1>{title}</h1>
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('@/components/molecules/Button', () => ({
+  default: ({ children, active }: { children: ReactNode; active?: boolean }) => (
+    <button aria-pressed={active}>{children}</button>
+  ),
+}));
+
+vi.mock('@/components/organisms/activity/ActiveCard', () => ({
+  default: ({ contentTitle }: { contentTitle: string }) => <article data-testid="active-card">{contentTitle}</article>,
+}));
+
+vi.mock('@/components/organisms/activity/ActiveVideoCard', () => ({
+  default: ({ contentTitle }: { contentTitle: string }) => <article data-testid="active-video-card">{contentTitle}</article>,
+}));
+
+const postActivities: ActivityPost[] = [
+  {
+    id: 'post-1',
+    type: 'B',
+    thumbnail: '/post.png',
+    title: '블로그 글',
+    description: '블로그 설명',
+    name: '작성자',
+    date: '2025-01-01',
+    link: 'https://example.com/post',
+    profile: '/profile.png',
+  },
+];
+
+const videoActivities: ActivityVideo[] = [
+  {
+    id: 'video-1',
+    type: 'V',
+    thumbnail: '/video.png',
+    title: '발표 영상',
+    description: '영상 설명',
+    name: '발표자',
+    date: '2025-01-02',
+    link: 'https://example.com/video',
+    profile: '/profile.png',
+  },
+];
+
+describe('Activity page', () => {
+  it('renders blog cards in the post tab', () => {
+    render(<Activity activityData={postActivities} currentTab="post" />);
+
+    expect(screen.getByRole('button', { name: '발표 영상' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '블로그' })).toBeInTheDocument();
+    expect(screen.getAllByTestId('active-card')).toHaveLength(1);
+    expect(screen.queryByTestId('active-video-card')).not.toBeInTheDocument();
+    expect(screen.getByText('블로그 글')).toBeInTheDocument();
+  });
+
+  it('renders video cards in the video tab', () => {
+    render(<Activity activityData={videoActivities} currentTab="video" />);
+
+    expect(screen.getAllByTestId('active-video-card')).toHaveLength(1);
+    expect(screen.queryByTestId('active-card')).not.toBeInTheDocument();
+    expect(screen.getByTestId('active-video-card')).toHaveTextContent('발표 영상');
+  });
+});

--- a/src/components/pages/Activity/index.tsx
+++ b/src/components/pages/Activity/index.tsx
@@ -1,3 +1,5 @@
+import { Flex } from '@sipe-team/side';
+
 import ContentWithTitle from '@/components/atoms/ContentWithTitle';
 import Layout from '@/components/atoms/Layout';
 import Button from '@/components/molecules/Button';
@@ -20,7 +22,7 @@ function Activity({ activityData, currentTab }: Props) {
   return (
     <Layout>
       <ContentWithTitle title="사이퍼 활동">
-        <div className={styles.typeWrapper}>
+        <Flex className={styles.typeWrapper}>
           <Button
             className={styles.periodButton}
             buttonType="chip"
@@ -37,13 +39,14 @@ function Activity({ activityData, currentTab }: Props) {
           >
             블로그
           </Button>
-        </div>
+        </Flex>
         <div className={styles.wrapper}>
-          <div
-            className={currentTab === 'post' ? styles.cards : styles.videoCards}
-          >
-            {currentTab === 'post' &&
-              activityData.map((activity) => (
+          {currentTab === 'post' ? (
+            <Flex
+              className={styles.cards}
+              direction="column"
+            >
+              {activityData.map((activity) => (
                 <ActiveCard
                   key={activity.link}
                   thumbnail={activity.thumbnail}
@@ -55,8 +58,12 @@ function Activity({ activityData, currentTab }: Props) {
                   createDate={activity.date}
                 />
               ))}
-            {currentTab === 'video' &&
-              activityData.map((activity) => (
+            </Flex>
+          ) : (
+            <div
+            className={currentTab === 'post' ? styles.cards : styles.videoCards}
+          >
+              {activityData.map((activity) => (
                 <ActiveVideoCard
                   key={activity.link}
                   thumbnail={activity.thumbnail}
@@ -66,7 +73,8 @@ function Activity({ activityData, currentTab }: Props) {
                   createDate={activity.date}
                 />
               ))}
-          </div>
+            </div>
+          )}
         </div>
       </ContentWithTitle>
     </Layout>

--- a/src/components/pages/Activity/index.tsx
+++ b/src/components/pages/Activity/index.tsx
@@ -57,11 +57,7 @@ function Activity({ activityData, currentTab }: Props) {
               ))}
             </Flex>
           ) : (
-            <div
-              className={
-                currentTab === 'post' ? styles.cards : styles.videoCards
-              }
-            >
+            <div className={styles.videoCards}>
               {activityData.map((activity) => (
                 <ActiveVideoCard
                   key={activity.link}

--- a/src/components/pages/Activity/index.tsx
+++ b/src/components/pages/Activity/index.tsx
@@ -42,10 +42,7 @@ function Activity({ activityData, currentTab }: Props) {
         </Flex>
         <div className={styles.wrapper}>
           {currentTab === 'post' ? (
-            <Flex
-              className={styles.cards}
-              direction="column"
-            >
+            <Flex className={styles.cards} direction="column">
               {activityData.map((activity) => (
                 <ActiveCard
                   key={activity.link}
@@ -61,8 +58,10 @@ function Activity({ activityData, currentTab }: Props) {
             </Flex>
           ) : (
             <div
-            className={currentTab === 'post' ? styles.cards : styles.videoCards}
-          >
+              className={
+                currentTab === 'post' ? styles.cards : styles.videoCards
+              }
+            >
               {activityData.map((activity) => (
                 <ActiveVideoCard
                   key={activity.link}

--- a/src/components/pages/People/index.module.scss
+++ b/src/components/pages/People/index.module.scss
@@ -18,7 +18,6 @@
 }
 
 .periodsWrapper {
-  display: flex;
   margin-bottom: 40px;
   gap: 16px;
 

--- a/src/components/pages/People/index.test.tsx
+++ b/src/components/pages/People/index.test.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import type { PeopleGeneration, PeopleItem } from '@/db/model';
+
+import People from './index';
+
+vi.mock('@/components/atoms/Layout', () => ({
+  default: ({ children }: { children: ReactNode }) => <div data-testid="layout">{children}</div>,
+}));
+
+vi.mock('@/components/atoms/ContentWithTitle', () => ({
+  default: ({ children, title }: { children: ReactNode; title: string }) => (
+    <section data-testid="content-with-title">
+      <h1>{title}</h1>
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('@/components/molecules/Button', () => ({
+  default: ({ children, active }: { children: ReactNode; active?: boolean }) => (
+    <button aria-pressed={active}>{children}</button>
+  ),
+}));
+
+vi.mock('@/components/organisms/people/UserCard', () => ({
+  default: ({ name }: { name: string }) => <article data-testid="user-card">{name}</article>,
+}));
+
+const peopleGenerations: PeopleGeneration[] = ['1', '2', '3'];
+const currentPeople: PeopleItem[] = [
+  {
+    id: '1',
+    period: '3',
+    isOrganizer: false,
+    thumbnail: '/person-1.png',
+    name: '홍길동',
+    part: 'Backend',
+    introduce: '안녕하세요',
+    review: '',
+  },
+  {
+    id: '2',
+    period: '3',
+    isOrganizer: true,
+    thumbnail: '/person-2.png',
+    name: '김영희',
+    part: 'Frontend',
+    introduce: '반갑습니다',
+    review: '좋았어요',
+  },
+];
+
+describe('People page', () => {
+  it('renders generation buttons and user cards', () => {
+    render(
+      <People currentPeople={currentPeople} peopleGenerations={peopleGenerations} selectedPeopleGeneration="3" />,
+    );
+
+    expect(screen.getByText('사이퍼 소개')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '1기' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '2기' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '3기' })).toBeInTheDocument();
+    expect(screen.getAllByTestId('user-card')).toHaveLength(2);
+    expect(screen.getByText('홍길동')).toBeInTheDocument();
+    expect(screen.getByText('김영희')).toBeInTheDocument();
+  });
+});

--- a/src/components/pages/People/index.test.tsx
+++ b/src/components/pages/People/index.test.tsx
@@ -7,7 +7,9 @@ import type { PeopleGeneration, PeopleItem } from '@/db/model';
 import People from './index';
 
 vi.mock('@/components/atoms/Layout', () => ({
-  default: ({ children }: { children: ReactNode }) => <div data-testid="layout">{children}</div>,
+  default: ({ children }: { children: ReactNode }) => (
+    <div data-testid="layout">{children}</div>
+  ),
 }));
 
 vi.mock('@/components/atoms/ContentWithTitle', () => ({
@@ -20,13 +22,19 @@ vi.mock('@/components/atoms/ContentWithTitle', () => ({
 }));
 
 vi.mock('@/components/molecules/Button', () => ({
-  default: ({ children, active }: { children: ReactNode; active?: boolean }) => (
-    <button aria-pressed={active}>{children}</button>
-  ),
+  default: ({
+    children,
+    active,
+  }: {
+    children: ReactNode;
+    active?: boolean;
+  }) => <button aria-pressed={active}>{children}</button>,
 }));
 
 vi.mock('@/components/organisms/people/UserCard', () => ({
-  default: ({ name }: { name: string }) => <article data-testid="user-card">{name}</article>,
+  default: ({ name }: { name: string }) => (
+    <article data-testid="user-card">{name}</article>
+  ),
 }));
 
 const peopleGenerations: PeopleGeneration[] = ['1', '2', '3'];
@@ -56,7 +64,11 @@ const currentPeople: PeopleItem[] = [
 describe('People page', () => {
   it('renders generation buttons and user cards', () => {
     render(
-      <People currentPeople={currentPeople} peopleGenerations={peopleGenerations} selectedPeopleGeneration="3" />,
+      <People
+        currentPeople={currentPeople}
+        peopleGenerations={peopleGenerations}
+        selectedPeopleGeneration="3"
+      />,
     );
 
     expect(screen.getByText('사이퍼 소개')).toBeInTheDocument();

--- a/src/components/pages/People/index.tsx
+++ b/src/components/pages/People/index.tsx
@@ -1,3 +1,5 @@
+import { Flex } from '@sipe-team/side';
+
 import ContentWithTitle from '@/components/atoms/ContentWithTitle';
 import Layout from '@/components/atoms/Layout';
 import Button from '@/components/molecules/Button';
@@ -21,7 +23,7 @@ function People({
   return (
     <Layout>
       <ContentWithTitle title="사이퍼 소개">
-        <div className={styles.periodsWrapper}>
+        <Flex className={styles.periodsWrapper}>
           {peopleGenerations.map((generation) => (
             <Button
               key={generation}
@@ -33,7 +35,7 @@ function People({
               {`${generation}기`}
             </Button>
           ))}
-        </div>
+        </Flex>
         <section className={styles.wrapper}>
           <div className={styles.contents}>
             {currentPeople.map((person) => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,8 @@
+import '@testing-library/jest-dom/vitest';
+
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,29 @@
+import path from 'path';
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        includePaths: [path.resolve(__dirname, 'src/styles')],
+        additionalData: `@import "${path.resolve(__dirname, 'src/styles/main')}";`,
+      },
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    css: true,
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 8
   cacheKey: 10
 
+"@adobe/css-tools@npm:^4.4.0":
+  version: 4.4.4
+  resolution: "@adobe/css-tools@npm:4.4.4"
+  checksum: 10/0abd4715737877e5aa5d730d6ec2cffae2131102ddc8310ac5ba3f457ffb2ef453324dbb5b927e3cbc3f81bdd29ce485754014c6e64f4577a49540c76e26ac6b
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
@@ -15,6 +22,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@asamuzakjp/css-color@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@asamuzakjp/css-color@npm:3.2.0"
+  dependencies:
+    "@csstools/css-calc": "npm:^2.1.3"
+    "@csstools/css-color-parser": "npm:^3.0.9"
+    "@csstools/css-parser-algorithms": "npm:^3.0.4"
+    "@csstools/css-tokenizer": "npm:^3.0.3"
+    lru-cache: "npm:^10.4.3"
+  checksum: 10/870f661460173174fef8bfebea0799ba26566f3aa7b307e5adabb7aae84fed2da68e40080104ed0c83b43c5be632ee409e65396af13bfe948a3ef4c2c729ecd9
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/code-frame@npm:7.24.7"
@@ -22,6 +42,17 @@ __metadata:
     "@babel/highlight": "npm:^7.24.7"
     picocolors: "npm:^1.0.0"
   checksum: 10/4812e94885ba7e3213d49583a155fdffb05292330f0a9b2c41b49288da70cf3c746a3fda0bf1074041a6d741c33f8d7be24be5e96f41ef77395eeddc5c9ff624
+  languageName: node
+  linkType: hard
+
+"@babel/code-frame@npm:^7.10.4":
+  version: 7.29.0
+  resolution: "@babel/code-frame@npm:7.29.0"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.28.5"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10/199e15ff89007dd30675655eec52481cb245c9fdf4f81e4dc1f866603b0217b57aff25f5ffa0a95bbc8e31eb861695330cd7869ad52cc211aa63016320ef72c5
   languageName: node
   linkType: hard
 
@@ -251,6 +282,13 @@ __metadata:
   version: 7.24.7
   resolution: "@babel/helper-validator-identifier@npm:7.24.7"
   checksum: 10/86875063f57361471b531dbc2ea10bbf5406e12b06d249b03827d361db4cad2388c6f00936bcd9dc86479f7e2c69ea21412c2228d4b3672588b754b70a449d4b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.28.5":
+  version: 7.28.5
+  resolution: "@babel/helper-validator-identifier@npm:7.28.5"
+  checksum: 10/8e5d9b0133702cfacc7f368bf792f0f8ac0483794877c6dca5fcb73810ee138e27527701826fb58a40a004f3a5ec0a2f3c3dd5e326d262530b119918f3132ba7
   languageName: node
   linkType: hard
 
@@ -1402,6 +1440,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.12.5":
+  version: 7.29.2
+  resolution: "@babel/runtime@npm:7.29.2"
+  checksum: 10/f55ba4052aa0255055b34371a145fbe69c29b37b49eaea14805b095bfb4153701486416e89392fd27ec8abafa53868be86e960b9f8f959fff91f2c8ac2a14b02
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.8.4":
   version: 7.25.0
   resolution: "@babel/runtime@npm:7.25.0"
@@ -1452,6 +1497,234 @@ __metadata:
   version: 2.0.0
   resolution: "@channel.io/channel-web-sdk-loader@npm:2.0.0"
   checksum: 10/11bf96fa8863a9800537f674225bc3fa67cea59592a8bd1fc9d333e5db899e08ff885bd3380f67b62e0ba7ab3252a7ba2df636cf58f84b562584830ade370f6a
+  languageName: node
+  linkType: hard
+
+"@csstools/color-helpers@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@csstools/color-helpers@npm:5.1.0"
+  checksum: 10/0138b3d5ccbe77aeccf6721fd008a53523c70e932f0c82dca24a1277ca780447e1d8357da47512ebf96358476f8764de57002f3e491920d67e69202f5a74c383
+  languageName: node
+  linkType: hard
+
+"@csstools/css-calc@npm:^2.1.3, @csstools/css-calc@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@csstools/css-calc@npm:2.1.4"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^3.0.5
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 10/06975b650c0f44c60eeb7afdb3fd236f2dd607b2c622e0bc908d3f54de39eb84e0692833320d03dac04bd6c1ab0154aa3fa0dd442bd9e5f917cf14d8e2ba8d74
+  languageName: node
+  linkType: hard
+
+"@csstools/css-color-parser@npm:^3.0.9":
+  version: 3.1.0
+  resolution: "@csstools/css-color-parser@npm:3.1.0"
+  dependencies:
+    "@csstools/color-helpers": "npm:^5.1.0"
+    "@csstools/css-calc": "npm:^2.1.4"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^3.0.5
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 10/4741095fdc4501e8e7ada4ed14fbf9dbbe6fea9b989818790ebca15657c29c62defbebacf18592cde2aa638a1d098bbe86d742d2c84ba932fbc00fac51cb8805
+  languageName: node
+  linkType: hard
+
+"@csstools/css-parser-algorithms@npm:^3.0.4":
+  version: 3.0.5
+  resolution: "@csstools/css-parser-algorithms@npm:3.0.5"
+  peerDependencies:
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 10/e93083b5cb36a3c1e7a47ce10cf62961d05bd1e4c608bb3ee50186ff740157ab0ec16a3956f7b86251efd10703034d849693201eea858ae904848c68d2d46ada
+  languageName: node
+  linkType: hard
+
+"@csstools/css-tokenizer@npm:^3.0.3":
+  version: 3.0.4
+  resolution: "@csstools/css-tokenizer@npm:3.0.4"
+  checksum: 10/eb6c84c086312f6bb8758dfe2c85addd7475b0927333c5e39a4d59fb210b9810f8c346972046f95e60a721329cffe98895abe451e51de753ad1ca7a8c24ec65f
+  languageName: node
+  linkType: hard
+
+"@esbuild/aix-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/aix-ppc64@npm:0.27.7"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm64@npm:0.27.7"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm@npm:0.27.7"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-x64@npm:0.27.7"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-arm64@npm:0.27.7"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-x64@npm:0.27.7"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.7"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-x64@npm:0.27.7"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm64@npm:0.27.7"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm@npm:0.27.7"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ia32@npm:0.27.7"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-loong64@npm:0.27.7"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-mips64el@npm:0.27.7"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ppc64@npm:0.27.7"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-riscv64@npm:0.27.7"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-s390x@npm:0.27.7"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-x64@npm:0.27.7"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.7"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-x64@npm:0.27.7"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.7"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-x64@npm:0.27.7"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.7"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/sunos-x64@npm:0.27.7"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-arm64@npm:0.27.7"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-ia32@npm:0.27.7"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-x64@npm:0.27.7"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1639,6 +1912,13 @@ __metadata:
   version: 1.5.0
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
   checksum: 10/4ed6123217569a1484419ac53f6ea0d9f3b57e5b57ab30d7c267bdb27792a27eb0e4b08e84a2680aa55cc2f2b411ffd6ec3db01c44fdc6dc43aca4b55f8374fd
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:^1.5.5":
+  version: 1.5.5
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
+  checksum: 10/5d9d207b462c11e322d71911e55e21a4e2772f71ffe8d6f1221b8eb5ae6774458c1d242f897fb0814e8714ca9a6b498abfa74dfe4f434493342902b1a48b33a5
   languageName: node
   linkType: hard
 
@@ -1842,6 +2122,181 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/6d5e1fac17b3eb79019a697581133dff23a3f6406f8ecfca476ab4a6a73baa53d66a7c9caeeebcc677363aa3b4132aa9d2168641ba9642658a2e4a297c05e4d3
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm-eabi@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.60.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-android-arm64@npm:4.60.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.60.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-x64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-darwin-x64@npm:4.60.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.60.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.60.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.60.2"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-musleabihf@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.60.2"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.60.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.60.2"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.60.2"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.60.2"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.60.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openbsd-x64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.60.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openharmony-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.60.2"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.60.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-ia32-msvc@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.60.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.60.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.2"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2190,10 +2645,84 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@testing-library/dom@npm:10.4.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^5.0.1"
+    aria-query: "npm:5.3.0"
+    dom-accessibility-api: "npm:^0.5.9"
+    lz-string: "npm:^1.5.0"
+    picocolors: "npm:1.1.1"
+    pretty-format: "npm:^27.0.2"
+  checksum: 10/7f93e09ea015f151f8b8f42cbab0b2b858999b5445f15239a72a612ef7716e672b14c40c421218194cf191cbecbde0afa6f3dc2cc83dda93ff6a4fb0237df6e6
+  languageName: node
+  linkType: hard
+
+"@testing-library/jest-dom@npm:^6.6.3":
+  version: 6.9.1
+  resolution: "@testing-library/jest-dom@npm:6.9.1"
+  dependencies:
+    "@adobe/css-tools": "npm:^4.4.0"
+    aria-query: "npm:^5.0.0"
+    css.escape: "npm:^1.5.1"
+    dom-accessibility-api: "npm:^0.6.3"
+    picocolors: "npm:^1.1.1"
+    redent: "npm:^3.0.0"
+  checksum: 10/409b4f519e4c68f4d31e3b0317338cc19098b9029513fca61aa2af8270086ae3956a1eaedd19bbce2d2c9e2cf9ff27a616c06556be7a26e101c0d529a0062233
+  languageName: node
+  linkType: hard
+
+"@testing-library/react@npm:^16.3.0":
+  version: 16.3.2
+  resolution: "@testing-library/react@npm:16.3.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+  peerDependencies:
+    "@testing-library/dom": ^10.0.0
+    "@types/react": ^18.0.0 || ^19.0.0
+    "@types/react-dom": ^18.0.0 || ^19.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/0ca88c6f672d00c2afd1bdedeff9b5382dd8157038efeb9762dc016731030075624be7106b92d2b5e5c52812faea85263e69272c14b6f8700eb48a4a8af6feef
+  languageName: node
+  linkType: hard
+
 "@trysound/sax@npm:0.2.0":
   version: 0.2.0
   resolution: "@trysound/sax@npm:0.2.0"
   checksum: 10/7379713eca480ac0d9b6c7b063e06b00a7eac57092354556c81027066eb65b61ea141a69d0cc2e15d32e05b2834d4c9c2184793a5e36bbf5daf05ee5676af18c
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "@types/aria-query@npm:5.0.4"
+  checksum: 10/c0084c389dc030daeaf0115a92ce43a3f4d42fc8fef2d0e22112d87a42798d4a15aac413019d4a63f868327d52ad6740ab99609462b442fe6b9286b172d2e82e
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10/e79947307dc235953622e65f83d2683835212357ca261389116ab90bed369ac862ba28b146b4fed08b503ae1e1a12cb93ce783f24bb8d562950469f4320e1c7c
+  languageName: node
+  linkType: hard
+
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10/249a27b0bb22f6aa28461db56afa21ec044fa0e303221a62dff81831b20c8530502175f1a49060f7099e7be06181078548ac47c668de79ff9880241968d43d0c
   languageName: node
   linkType: hard
 
@@ -2221,6 +2750,13 @@ __metadata:
   version: 1.0.5
   resolution: "@types/estree@npm:1.0.5"
   checksum: 10/7de6d928dd4010b0e20c6919e1a6c27b61f8d4567befa89252055fad503d587ecb9a1e3eab1b1901f923964d7019796db810b7fd6430acb26c32866d126fd408
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:1.0.8, @types/estree@npm:^1.0.0":
+  version: 1.0.8
+  resolution: "@types/estree@npm:1.0.8"
+  checksum: 10/25a4c16a6752538ffde2826c2cc0c6491d90e69cd6187bef4a006dd2c3c45469f049e643d7e516c515f21484dc3d48fd5c870be158a5beb72f5baf3dc43e4099
   languageName: node
   linkType: hard
 
@@ -2554,6 +3090,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/expect@npm:3.2.4"
+  dependencies:
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:3.2.4"
+    "@vitest/utils": "npm:3.2.4"
+    chai: "npm:^5.2.0"
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10/dc69ce886c13714dfbbff78f2d2cb7eb536017e82301a73c42d573a9e9d2bf91005ac7abd9b977adf0a3bd431209f45a8ac2418029b68b0a377e092607c843ce
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/mocker@npm:3.2.4"
+  dependencies:
+    "@vitest/spy": "npm:3.2.4"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.17"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10/5e92431b6ed9fc1679060e4caef3e4623f4750542a5d7cd944774f8217c4d231e273202e8aea00bab33260a5a9222ecb7005d80da0348c3c829bd37d123071a8
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:3.2.4, @vitest/pretty-format@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/pretty-format@npm:3.2.4"
+  dependencies:
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10/8dd30cbf956e01fbab042fe651fb5175d9f0cd00b7b569a46cd98df89c4fec47dab12916201ad6e09a4f25f2a2ec8927a4bfdc61118593097f759c90b18a51d4
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/runner@npm:3.2.4"
+  dependencies:
+    "@vitest/utils": "npm:3.2.4"
+    pathe: "npm:^2.0.3"
+    strip-literal: "npm:^3.0.0"
+  checksum: 10/197bd55def519ef202f990b7c1618c212380831827c116240871033e4973decb780503c705ba9245a12bd8121f3ac4086ffcb3e302148b62d9bd77fd18dd1deb
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/snapshot@npm:3.2.4"
+  dependencies:
+    "@vitest/pretty-format": "npm:3.2.4"
+    magic-string: "npm:^0.30.17"
+    pathe: "npm:^2.0.3"
+  checksum: 10/acfb682491b9ca9345bf9fed02c2779dec43e0455a380c1966b0aad8dd81c79960902cf34621ab48fe80a0eaf8c61cc42dec186a1321dc3c9897ef2ebd5f1bc4
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/spy@npm:3.2.4"
+  dependencies:
+    tinyspy: "npm:^4.0.3"
+  checksum: 10/7d38c299f42a8c7e5e41652b203af98ca54e63df69c3b072d0e401d5a57fbbba3e39d8538ac1b3022c26718a6388d0bcc222bc2f07faab75942543b9247c007d
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/utils@npm:3.2.4"
+  dependencies:
+    "@vitest/pretty-format": "npm:3.2.4"
+    loupe: "npm:^3.1.4"
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10/7f12ef63bd8ee13957744d1f336b0405f164ade4358bf9dfa531f75bbb58ffac02bf61aba65724311ddbc50b12ba54853a169e59c6b837c16086173b9a480710
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/ast@npm:1.12.1, @webassemblyjs/ast@npm:^1.12.1":
   version: 1.12.1
   resolution: "@webassemblyjs/ast@npm:1.12.1"
@@ -2771,6 +3390,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"agent-base@npm:^7.1.2":
+  version: 7.1.4
+  resolution: "agent-base@npm:7.1.4"
+  checksum: 10/79bef167247789f955aaba113bae74bf64aa1e1acca4b1d6bb444bdf91d82c3e07e9451ef6a6e2e35e8f71a6f97ce33e3d855a5328eb9fad1bc3cc4cfd031ed8
+  languageName: node
+  linkType: hard
+
 "aggregate-error@npm:^3.0.0":
   version: 3.1.0
   resolution: "aggregate-error@npm:3.1.0"
@@ -2843,6 +3469,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-styles@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "ansi-styles@npm:5.2.0"
+  checksum: 10/d7f4e97ce0623aea6bc0d90dcd28881ee04cba06c570b97fd3391bd7a268eedfd9d5e2dd4fdcbdd82b8105df5faf6f24aaedc08eaf3da898e702db5948f63469
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^6.0.0, ansi-styles@npm:^6.1.0, ansi-styles@npm:^6.2.1":
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
@@ -2864,6 +3497,22 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 10/18640244e641a417ec75a9bd38b0b2b6b95af5199aa241b131d4b2fb206f334d7ecc600bd194861610a5579084978bfcbb02baa399dbe442d56d0ae5e60dbaef
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:5.3.0":
+  version: 5.3.0
+  resolution: "aria-query@npm:5.3.0"
+  dependencies:
+    dequal: "npm:^2.0.3"
+  checksum: 10/c3e1ed127cc6886fea4732e97dd6d3c3938e64180803acfb9df8955517c4943760746ffaf4020ce8f7ffaa7556a3b5f85c3769a1f5ca74a1288e02d042f9ae4e
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:^5.0.0":
+  version: 5.3.2
+  resolution: "aria-query@npm:5.3.2"
+  checksum: 10/b2fe9bc98bd401bc322ccb99717c1ae2aaf53ea0d468d6e7aebdc02fac736e4a99b46971ee05b783b08ade23c675b2d8b60e4a1222a95f6e27bc4d2a0bfdcc03
   languageName: node
   linkType: hard
 
@@ -2987,6 +3636,13 @@ __metadata:
     get-intrinsic: "npm:^1.2.6"
     is-array-buffer: "npm:^3.0.4"
   checksum: 10/4821ebdfe7d699f910c7f09bc9fa996f09b96b80bccb4f5dd4b59deae582f6ad6e505ecef6376f8beac1eda06df2dbc89b70e82835d104d6fcabd33c1aed1ae9
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10/a0789dd882211b87116e81e2648ccb7f60340b34f19877dd020b39ebb4714e475eb943e14ba3e22201c221ef6645b7bfe10297e76b6ac95b48a9898c1211ce66
   languageName: node
   linkType: hard
 
@@ -3153,6 +3809,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 10/002769a0fbfc51c062acd2a59df465a2a947916b02ac50b56c69ec6c018ee99ac3e7f4dd7366334ea847f1ecacf4defaa61bcd2ac283db50156ce1f1d8c8ad42
+  languageName: node
+  linkType: hard
+
 "cacache@npm:^18.0.0":
   version: 18.0.4
   resolution: "cacache@npm:18.0.4"
@@ -3239,6 +3902,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^5.2.0":
+  version: 5.3.3
+  resolution: "chai@npm:5.3.3"
+  dependencies:
+    assertion-error: "npm:^2.0.1"
+    check-error: "npm:^2.1.1"
+    deep-eql: "npm:^5.0.1"
+    loupe: "npm:^3.1.0"
+    pathval: "npm:^2.0.0"
+  checksum: 10/0d0ef63106083b05c7ba510697cd9991a02b8df5984a7d010ab4af10205c7a1f27d1c06bfa4679540894295ac4dcc22aa2a281e2e4cfe5133c1db379626689a2
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -3264,6 +3940,13 @@ __metadata:
   version: 5.4.1
   resolution: "chalk@npm:5.4.1"
   checksum: 10/29df3ffcdf25656fed6e95962e2ef86d14dfe03cd50e7074b06bad9ffbbf6089adbb40f75c00744d843685c8d008adaf3aed31476780312553caf07fa86e5bc7
+  languageName: node
+  linkType: hard
+
+"check-error@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "check-error@npm:2.1.3"
+  checksum: 10/f1868d3db60f5a7da92e140ccf33e9152bf6124161fa9b7a4ae8eafdb05e66e1f13570401e56f314f037b0f1b71eaf38ad0c7256310d82c6105e9d85ded0f202
   languageName: node
   linkType: hard
 
@@ -3518,6 +4201,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: 10/f6d38088d870a961794a2580b2b2af1027731bb43261cfdce14f19238a88664b351cc8978abc20f06cc6bbde725699dec8deb6fe9816b139fc3f2af28719e774
+  languageName: node
+  linkType: hard
+
 "csso@npm:^5.0.5":
   version: 5.0.5
   resolution: "csso@npm:5.0.5"
@@ -3527,10 +4217,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cssstyle@npm:^4.2.1":
+  version: 4.6.0
+  resolution: "cssstyle@npm:4.6.0"
+  dependencies:
+    "@asamuzakjp/css-color": "npm:^3.2.0"
+    rrweb-cssom: "npm:^0.8.0"
+  checksum: 10/1cb25c9d66b87adb165f978b75cdeb6f225d7e31ba30a8934666046a0be037e4e7200d359bfa79d4f1a4aef1083ea09633b81bcdb36a2f2ac888e8c73ea3a289
+  languageName: node
+  linkType: hard
+
 "csstype@npm:^3.0.2":
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 10/f593cce41ff5ade23f44e77521e3a1bcc2c64107041e1bf6c3c32adc5187d0d60983292fda326154d20b01079e24931aa5b08e4467cc488b60bb1e7f6d478ade
+  languageName: node
+  linkType: hard
+
+"data-urls@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "data-urls@npm:5.0.0"
+  dependencies:
+    whatwg-mimetype: "npm:^4.0.0"
+    whatwg-url: "npm:^14.0.0"
+  checksum: 10/5c40568c31b02641a70204ff233bc4e42d33717485d074244a98661e5f2a1e80e38fe05a5755dfaf2ee549f2ab509d6a3af2a85f4b2ad2c984e5d176695eaf46
   languageName: node
   linkType: hard
 
@@ -3624,6 +4334,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.4.1":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10/9ada3434ea2993800bd9a1e320bd4aa7af69659fb51cca685d390949434bc0a8873c21ed7c9b852af6f2455a55c6d050aa3937d52b3c69f796dab666f762acad
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:^10.5.0":
+  version: 10.6.0
+  resolution: "decimal.js@npm:10.6.0"
+  checksum: 10/c0d45842d47c311d11b38ce7ccc911121953d4df3ebb1465d92b31970eb4f6738a065426a06094af59bee4b0d64e42e7c8984abd57b6767c64ea90cf90bb4a69
+  languageName: node
+  linkType: hard
+
+"deep-eql@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "deep-eql@npm:5.0.2"
+  checksum: 10/a529b81e2ef8821621d20a36959a0328873a3e49d393ad11f8efe8559f31239494c2eb889b80342808674c475802ba95b9d6c4c27641b9a029405104c1b59fcf
+  languageName: node
+  linkType: hard
+
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
@@ -3667,6 +4403,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 10/6ff05a7561f33603df87c45e389c9ac0a95e3c056be3da1a0c4702149e3a7f6fe5ffbb294478687ba51a9e95f3a60e8b6b9005993acd79c292c7d15f71964b6b
+  languageName: node
+  linkType: hard
+
 "dir-glob@npm:^3.0.1":
   version: 3.0.1
   resolution: "dir-glob@npm:3.0.1"
@@ -3682,6 +4425,20 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10/555684f77e791b17173ea86e2eea45ef26c22219cb64670669c4f4bebd26dbc95cd90ec1f4159e9349a6bb9eb892ce4dde8cd0139e77bedd8bf4518238618474
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 10/377b4a7f9eae0a5d72e1068c369c99e0e4ca17fdfd5219f3abd32a73a590749a267475a59d7b03a891f9b673c27429133a818c44b2e47e32fec024b34274e2ca
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "dom-accessibility-api@npm:0.6.3"
+  checksum: 10/83d3371f8226487fbad36e160d44f1d9017fb26d46faba6a06fcad15f34633fc827b8c3e99d49f71d5f3253d866e2131826866fd0a3c86626f8eccfc361881ff
   languageName: node
   linkType: hard
 
@@ -3818,6 +4575,13 @@ __metadata:
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 10/ede2a35c9bce1aeccd055a1b445d41c75a14a2bb1cd22e242f20cf04d236cdcd7f9c859eb83f76885327bfae0c25bf03303665ee1ce3d47c5927b98b0e3e3d48
+  languageName: node
+  linkType: hard
+
+"entities@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "entities@npm:6.0.1"
+  checksum: 10/62af1307202884349d2867f0aac5c60d8b57102ea0b0e768b16246099512c28e239254ad772d6834e7e14cb1b6f153fc3d0c031934e3183b086c86d3838d874a
   languageName: node
   linkType: hard
 
@@ -4018,6 +4782,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "es-module-lexer@npm:1.7.0"
+  checksum: 10/b6f3e576a3fed4d82b0d0ad4bbf6b3a5ad694d2e7ce8c4a069560da3db6399381eaba703616a182b16dde50ce998af64e07dcf49f2ae48153b9e07be3f107087
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0":
   version: 1.0.0
   resolution: "es-object-atoms@npm:1.0.0"
@@ -4087,6 +4858,95 @@ __metadata:
     is-date-object: "npm:^1.0.5"
     is-symbol: "npm:^1.0.4"
   checksum: 10/17faf35c221aad59a16286cbf58ef6f080bf3c485dff202c490d074d8e74da07884e29b852c245d894eac84f73c58330ec956dfd6d02c0b449d75eb1012a3f9b
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.27.0":
+  version: 0.27.7
+  resolution: "esbuild@npm:0.27.7"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.27.7"
+    "@esbuild/android-arm": "npm:0.27.7"
+    "@esbuild/android-arm64": "npm:0.27.7"
+    "@esbuild/android-x64": "npm:0.27.7"
+    "@esbuild/darwin-arm64": "npm:0.27.7"
+    "@esbuild/darwin-x64": "npm:0.27.7"
+    "@esbuild/freebsd-arm64": "npm:0.27.7"
+    "@esbuild/freebsd-x64": "npm:0.27.7"
+    "@esbuild/linux-arm": "npm:0.27.7"
+    "@esbuild/linux-arm64": "npm:0.27.7"
+    "@esbuild/linux-ia32": "npm:0.27.7"
+    "@esbuild/linux-loong64": "npm:0.27.7"
+    "@esbuild/linux-mips64el": "npm:0.27.7"
+    "@esbuild/linux-ppc64": "npm:0.27.7"
+    "@esbuild/linux-riscv64": "npm:0.27.7"
+    "@esbuild/linux-s390x": "npm:0.27.7"
+    "@esbuild/linux-x64": "npm:0.27.7"
+    "@esbuild/netbsd-arm64": "npm:0.27.7"
+    "@esbuild/netbsd-x64": "npm:0.27.7"
+    "@esbuild/openbsd-arm64": "npm:0.27.7"
+    "@esbuild/openbsd-x64": "npm:0.27.7"
+    "@esbuild/openharmony-arm64": "npm:0.27.7"
+    "@esbuild/sunos-x64": "npm:0.27.7"
+    "@esbuild/win32-arm64": "npm:0.27.7"
+    "@esbuild/win32-ia32": "npm:0.27.7"
+    "@esbuild/win32-x64": "npm:0.27.7"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10/262b16c4a33cb70e9f054759a7ce420541649315eef7b064172c795021ccce322e56c3f5fd52e8842873f1c23745f3ab62311a24860950bd5406ba77b36b8529
   languageName: node
   linkType: hard
 
@@ -4328,6 +5188,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10/a65728d5727b71de172c5df323385755a16c0fdab8234dc756c3854cfee343261ddfbb72a809a5660fac8c75d960bb3e21aa898c2d7e9b19bb298482ca58a3af
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -4363,6 +5232,13 @@ __metadata:
     signal-exit: "npm:^4.1.0"
     strip-final-newline: "npm:^3.0.0"
   checksum: 10/d2ab5fe1e2bb92b9788864d0713f1fce9a07c4594e272c0c97bc18c90569897ab262e4ea58d27a694d288227a2e24f16f5e2575b44224ad9983b799dc7f1098d
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.2.1":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 10/a5fada3d0c621649261f886e7d93e6bf80ce26d8a86e5d517e38301b8baec8450ab2cb94ba6e7a0a6bf2fc9ee55f54e1b06938ef1efa52ddcfeffbfa01acbbcc
   languageName: node
   linkType: hard
 
@@ -4453,6 +5329,18 @@ __metadata:
   dependencies:
     reusify: "npm:^1.0.4"
   checksum: 10/a443180068b527dd7b3a63dc7f2a47ceca2f3e97b9c00a1efe5538757e6cc4056a3526df94308075d7727561baf09ebaa5b67da8dcbddb913a021c5ae69d1f69
+  languageName: node
+  linkType: hard
+
+"fdir@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "fdir@npm:6.5.0"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 10/14ca1c9f0a0e8f4f2e9bf4e8551065a164a09545dae548c12a18d238b72e51e5a7b39bd8e5494b56463a0877672d0a6c1ef62c6fa0677db1b0c847773be939b1
   languageName: node
   linkType: hard
 
@@ -4598,7 +5486,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.2":
+"fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -4617,7 +5505,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -5006,6 +5894,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-encoding-sniffer@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "html-encoding-sniffer@npm:4.0.0"
+  dependencies:
+    whatwg-encoding: "npm:^3.1.1"
+  checksum: 10/e86efd493293a5671b8239bd099d42128433bb3c7b0fdc7819282ef8e118a21f5dead0ad6f358e024a4e5c84f17ebb7a9b36075220fac0a6222b207248bede6f
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
@@ -5013,7 +5910,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^7.0.0":
+"http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.2":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
@@ -5033,6 +5930,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"https-proxy-agent@npm:^7.0.6":
+  version: 7.0.6
+  resolution: "https-proxy-agent@npm:7.0.6"
+  dependencies:
+    agent-base: "npm:^7.1.2"
+    debug: "npm:4"
+  checksum: 10/784b628cbd55b25542a9d85033bdfd03d4eda630fb8b3c9477959367f3be95dc476ed2ecbb9836c359c7c698027fc7b45723a302324433590f45d6c1706e8c13
+  languageName: node
+  linkType: hard
+
 "human-signals@npm:^5.0.0":
   version: 5.0.0
   resolution: "human-signals@npm:5.0.0"
@@ -5049,7 +5956,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -5371,6 +6278,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-potential-custom-element-name@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-potential-custom-element-name@npm:1.0.1"
+  checksum: 10/ced7bbbb6433a5b684af581872afe0e1767e2d1146b2207ca0068a648fb5cab9d898495d1ac0583524faaf24ca98176a7d9876363097c2d14fee6dd324f3a1ab
+  languageName: node
+  linkType: hard
+
 "is-regex@npm:^1.1.4":
   version: 1.1.4
   resolution: "is-regex@npm:1.1.4"
@@ -5590,6 +6504,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-tokens@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "js-tokens@npm:9.0.1"
+  checksum: 10/3288ba73bb2023adf59501979fb4890feb6669cc167b13771b226814fde96a1583de3989249880e3f4d674040d1815685db9a9880db9153307480d39dc760365
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:^4.1.0":
   version: 4.1.0
   resolution: "js-yaml@npm:4.1.0"
@@ -5605,6 +6526,39 @@ __metadata:
   version: 1.1.0
   resolution: "jsbn@npm:1.1.0"
   checksum: 10/bebe7ae829bbd586ce8cbe83501dd8cb8c282c8902a8aeeed0a073a89dc37e8103b1244f3c6acd60278bcbfe12d93a3f83c9ac396868a3b3bbc3c5e5e3b648ef
+  languageName: node
+  linkType: hard
+
+"jsdom@npm:^26.1.0":
+  version: 26.1.0
+  resolution: "jsdom@npm:26.1.0"
+  dependencies:
+    cssstyle: "npm:^4.2.1"
+    data-urls: "npm:^5.0.0"
+    decimal.js: "npm:^10.5.0"
+    html-encoding-sniffer: "npm:^4.0.0"
+    http-proxy-agent: "npm:^7.0.2"
+    https-proxy-agent: "npm:^7.0.6"
+    is-potential-custom-element-name: "npm:^1.0.1"
+    nwsapi: "npm:^2.2.16"
+    parse5: "npm:^7.2.1"
+    rrweb-cssom: "npm:^0.8.0"
+    saxes: "npm:^6.0.0"
+    symbol-tree: "npm:^3.2.4"
+    tough-cookie: "npm:^5.1.1"
+    w3c-xmlserializer: "npm:^5.0.0"
+    webidl-conversions: "npm:^7.0.0"
+    whatwg-encoding: "npm:^3.1.1"
+    whatwg-mimetype: "npm:^4.0.0"
+    whatwg-url: "npm:^14.1.1"
+    ws: "npm:^8.18.0"
+    xml-name-validator: "npm:^5.0.0"
+  peerDependencies:
+    canvas: ^3.0.0
+  peerDependenciesMeta:
+    canvas:
+      optional: true
+  checksum: 10/39d78c4889cac20826393400dce1faed1666e9244fe0c8342a8f08c315375878e6be7fcfe339a33d6ff1a083bfe9e71b16d56ecf4d9a87db2da8c795925ea8c1
   languageName: node
   linkType: hard
 
@@ -5833,6 +6787,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loupe@npm:^3.1.0, loupe@npm:^3.1.4":
+  version: 3.2.1
+  resolution: "loupe@npm:3.2.1"
+  checksum: 10/a4d78ec758aaa04e0e35d5cd1c15e970beb9cdbfd3d0f34f98b9bcda489f896a7190b3b6cc40b7a6dcb8e97e82e96eafaae10096aaa469804acdba6f7c2bde5f
+  languageName: node
+  linkType: hard
+
 "lower-case@npm:^2.0.2":
   version: 2.0.2
   resolution: "lower-case@npm:2.0.2"
@@ -5842,7 +6803,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0":
+"lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0, lru-cache@npm:^10.4.3":
   version: 10.4.3
   resolution: "lru-cache@npm:10.4.3"
   checksum: 10/e6e90267360476720fa8e83cc168aa2bf0311f3f2eea20a6ba78b90a885ae72071d9db132f40fda4129c803e7dcec3a6b6a6fbb44ca90b081630b810b5d6a41a
@@ -5855,6 +6816,24 @@ __metadata:
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10/951d2673dcc64a7fb888bf3d13bc2fdf923faca97d89cdb405ba3dfff77e2b26e5798d405e78fcd7094c9e7b8b4dab2ddc5a4f8a11928af24a207b7c738ca3f8
+  languageName: node
+  linkType: hard
+
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 10/e86f0280e99a8d8cd4eef24d8601ddae15ce54e43ac9990dfcb79e1e081c255ad24424a30d78d2ad8e51a8ce82a66a930047fed4b4aa38c6f0b392ff9300edfc
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.17":
+  version: 0.30.21
+  resolution: "magic-string@npm:0.30.21"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10/57d5691f41ed40d962d8bd300148114f53db67fadbff336207db10a99f2bdf4a1be9cac3a68ee85dba575912ee1d4402e4396408196ec2d3afd043b076156221
   languageName: node
   linkType: hard
 
@@ -5960,6 +6939,13 @@ __metadata:
   version: 5.0.1
   resolution: "mimic-function@npm:5.0.1"
   checksum: 10/eb5893c99e902ccebbc267c6c6b83092966af84682957f79313311edb95e8bb5f39fb048d77132b700474d1c86d90ccc211e99bae0935447a4834eb4c882982c
+  languageName: node
+  linkType: hard
+
+"min-indent@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "min-indent@npm:1.0.1"
+  checksum: 10/bfc6dd03c5eaf623a4963ebd94d087f6f4bbbfd8c41329a7f09706b0cb66969c4ddd336abeb587bc44bc6f08e13bf90f0b374f9d71f9f01e04adc2cd6f083ef1
   languageName: node
   linkType: hard
 
@@ -6085,6 +7071,15 @@ __metadata:
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10/aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.11":
+  version: 3.3.11
+  resolution: "nanoid@npm:3.3.11"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10/73b5afe5975a307aaa3c95dfe3334c52cdf9ae71518176895229b8d65ab0d1c0417dd081426134eb7571c055720428ea5d57c645138161e7d10df80815527c48
   languageName: node
   linkType: hard
 
@@ -6260,6 +7255,13 @@ __metadata:
   dependencies:
     boolbase: "npm:^1.0.0"
   checksum: 10/5afc3dafcd1573b08877ca8e6148c52abd565f1d06b1eb08caf982e3fa289a82f2cae697ffb55b5021e146d60443f1590a5d6b944844e944714a5b549675bcd3
+  languageName: node
+  linkType: hard
+
+"nwsapi@npm:^2.2.16":
+  version: 2.2.23
+  resolution: "nwsapi@npm:2.2.23"
+  checksum: 10/aa4a570039c33d70b51436d1bb533f3e2c33c488ccbe9b09285c46a6cee5ef266fd60103461085c6954ba52460786a8138f042958328c7c1b4763898eb3dadfa
   languageName: node
   linkType: hard
 
@@ -6461,6 +7463,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse5@npm:^7.2.1":
+  version: 7.3.0
+  resolution: "parse5@npm:7.3.0"
+  dependencies:
+    entities: "npm:^6.0.0"
+  checksum: 10/b0e48be20b820c655b138b86fa6fb3a790de6c891aa2aba536524f8027b4dca4fe538f11a0e5cf2f6f847d120dbb9e4822dcaeb933ff1e10850a2ef0154d1d88
+  languageName: node
+  linkType: hard
+
 "path-exists@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
@@ -6506,6 +7517,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10/01e9a69928f39087d96e1751ce7d6d50da8c39abf9a12e0ac2389c42c83bc76f78c45a475bd9026a02e6a6f79be63acc75667df855862fe567d99a00a540d23d
+  languageName: node
+  linkType: hard
+
+"pathval@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "pathval@npm:2.0.1"
+  checksum: 10/f5e8b82f6b988a5bba197970af050268fd800780d0f9ee026e6f0b544ac4b17ab52bebeabccb790d63a794530a1641ae399ad07ecfc67ad337504c85dc9e5693
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:1.1.1, picocolors@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: 10/e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.0.0, picocolors@npm:^1.0.1":
   version: 1.0.1
   resolution: "picocolors@npm:1.0.1"
@@ -6517,6 +7549,13 @@ __metadata:
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10/60c2595003b05e4535394d1da94850f5372c9427ca4413b71210f437f7b2ca091dbd611c45e8b37d10036fa8eade25c1b8951654f9d3973bfa66a2ff4d3b08bc
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10/f6ef80a3590827ce20378ae110ac78209cc4f74d39236370f1780f957b7ee41c12acde0e4651b90f39983506fd2f5e449994716f516db2e9752924aff8de93ce
   languageName: node
   linkType: hard
 
@@ -6571,6 +7610,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:^8.5.6":
+  version: 8.5.10
+  resolution: "postcss@npm:8.5.10"
+  dependencies:
+    nanoid: "npm:^3.3.11"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10/7eac6169e535b63c8412e94d4f6047fc23efa3e9dde804b541940043c831b25f1cd867d83cd2c4371ad2450c8abcb42c208aa25668c1f0f3650d7f72faf711a8
+  languageName: node
+  linkType: hard
+
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -6593,6 +7643,17 @@ __metadata:
   bin:
     prettier: bin/prettier.cjs
   checksum: 10/5beac1f30b5b40162532b8e2f7c3a4eb650910a2695e9c8512a62ffdc09dae93190c29db9107fa7f26d1b6c71aad3628ecb9b5de1ecb0911191099be109434d7
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^27.0.2":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^17.0.1"
+  checksum: 10/248990cbef9e96fb36a3e1ae6b903c551ca4ddd733f8d0912b9cc5141d3d0b3f9f8dfb4d799fb1c6723382c9c2083ffbfa4ad43ff9a0e7535d32d41fd5f01da6
   languageName: node
   linkType: hard
 
@@ -6631,7 +7692,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0":
+"punycode@npm:^2.1.0, punycode@npm:^2.3.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10/febdc4362bead22f9e2608ff0171713230b57aff9dddc1c273aa2a651fbd366f94b7d6a71d78342a7c0819906750351ca7f2edd26ea41b626d87d6a13d1bd059
@@ -6673,6 +7734,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^17.0.1":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 10/73b36281e58eeb27c9cc6031301b6ae19ecdc9f18ae2d518bdb39b0ac564e65c5779405d623f1df9abf378a13858b79442480244bd579968afc1faf9a2ce5e05
+  languageName: node
+  linkType: hard
+
 "react-simple-toasts@npm:^5.10.1":
   version: 5.10.1
   resolution: "react-simple-toasts@npm:5.10.1"
@@ -6698,6 +7766,16 @@ __metadata:
   dependencies:
     picomatch: "npm:^2.2.1"
   checksum: 10/196b30ef6ccf9b6e18c4e1724b7334f72a093d011a99f3b5920470f0b3406a51770867b3e1ae9711f227ef7a7065982f6ee2ce316746b2cb42c88efe44297fe7
+  languageName: node
+  linkType: hard
+
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: "npm:^4.0.0"
+    strip-indent: "npm:^3.0.0"
+  checksum: 10/fa1ef20404a2d399235e83cc80bd55a956642e37dd197b4b612ba7327bf87fa32745aeb4a1634b2bab25467164ab4ed9c15be2c307923dd08b0fe7c52431ae6b
   languageName: node
   linkType: hard
 
@@ -6890,6 +7968,103 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:^4.43.0":
+  version: 4.60.2
+  resolution: "rollup@npm:4.60.2"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": "npm:4.60.2"
+    "@rollup/rollup-android-arm64": "npm:4.60.2"
+    "@rollup/rollup-darwin-arm64": "npm:4.60.2"
+    "@rollup/rollup-darwin-x64": "npm:4.60.2"
+    "@rollup/rollup-freebsd-arm64": "npm:4.60.2"
+    "@rollup/rollup-freebsd-x64": "npm:4.60.2"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.60.2"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.60.2"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-x64-musl": "npm:4.60.2"
+    "@rollup/rollup-openbsd-x64": "npm:4.60.2"
+    "@rollup/rollup-openharmony-arm64": "npm:4.60.2"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.60.2"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.60.2"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.60.2"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.60.2"
+    "@types/estree": "npm:1.0.8"
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-loong64-gnu":
+      optional: true
+    "@rollup/rollup-linux-loong64-musl":
+      optional: true
+    "@rollup/rollup-linux-ppc64-gnu":
+      optional: true
+    "@rollup/rollup-linux-ppc64-musl":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10/354041c7d7f745866cc001bb09d157ae8c0602e82311823e724aa85a45c16346a09bd6bced9f773b0a16aba66abaf45e2952ec643e694a4b30df6dc69daa47ce
+  languageName: node
+  linkType: hard
+
+"rrweb-cssom@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "rrweb-cssom@npm:0.8.0"
+  checksum: 10/07521ee36fb6569c17906afad1ac7ff8f099d49ade9249e190693ac36cdf27f88d9acf0cc66978935d5d0a23fca105643d7e9125b9a9d91ed9db9e02d31d7d80
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -6987,6 +8162,15 @@ __metadata:
   bin:
     sass: sass.js
   checksum: 10/4bf6e3007fef62dd6dfc657c89c2890872a6b5dc43e2dc4d61bcf9ae1bdc2dd95b59454a3cbd3c8363c98b673b028e1578b26135190d0f2a8a184a38ab41e99b
+  languageName: node
+  linkType: hard
+
+"saxes@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "saxes@npm:6.0.0"
+  dependencies:
+    xmlchars: "npm:^2.2.0"
+  checksum: 10/97b50daf6ca3a153e89842efa18a862e446248296622b7473c169c84c823ee8a16e4a43bac2f73f11fc8cb9168c73fbb0d73340f26552bac17970e9052367aa9
   languageName: node
   linkType: hard
 
@@ -7157,6 +8341,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10/e93ff66c6531a079af8fb217240df01f980155b5dc408d2d7bebc398dd284e383eb318153bf8acd4db3c4fe799aa5b9a641e38b0ba3b1975700b1c89547ea4e7
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
@@ -7175,6 +8366,9 @@ __metadata:
     "@playwright/test": "npm:^1.49.1"
     "@sipe-team/side": "npm:^0.2.5"
     "@svgr/webpack": "npm:8.1.0"
+    "@testing-library/dom": "npm:^10.4.1"
+    "@testing-library/jest-dom": "npm:^6.6.3"
+    "@testing-library/react": "npm:^16.3.0"
     "@types/node": "npm:^20.12.2"
     "@types/react": "npm:^18.3.4"
     "@types/react-dom": "npm:^18.3.0"
@@ -7196,6 +8390,7 @@ __metadata:
     google-auth-library: "npm:^9.14.0"
     google-spreadsheet: "npm:^4.1.2"
     husky: "npm:^9.1.7"
+    jsdom: "npm:^26.1.0"
     lint-staged: "npm:^15.5.0"
     next: "npm:^14.2.11"
     prettier: "npm:^3.3.3"
@@ -7208,6 +8403,7 @@ __metadata:
     typescript: "npm:^5.5.4"
     typescript-eslint: "npm:^8.28.0"
     usehooks-ts: "npm:^3.1.0"
+    vitest: "npm:^3.2.4"
     webpack: "npm:5.93.0"
   languageName: unknown
   linkType: soft
@@ -7284,6 +8480,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 10/ff9d8c8bf096d534a5b7707e0382ef827b4dd360a577d3f34d2b9f48e12c9d230b5747974ee7c607f0df65113732711bb701fe9ece3c7edbd43cb2294d707df3
+  languageName: node
+  linkType: hard
+
 "source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
@@ -7314,6 +8517,20 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10/f92c1b3cc9bfd0a925417412d07d999935917bc87049f43ebec41074661d64cf720315661844106a77da9f8204b6d55ae29f9514e673083cae39464343af2a8b
+  languageName: node
+  linkType: hard
+
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10/2d4dc4e64e2db796de4a3c856d5943daccdfa3dd092e452a1ce059c81e9a9c29e0b9badba91b43ef0d5ff5c04ee62feb3bcc559a804e16faf447bac2d883aa99
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.9.0":
+  version: 3.10.0
+  resolution: "std-env@npm:3.10.0"
+  checksum: 10/19c9cda4f370b1ffae2b8b08c72167d8c3e5cfa972aaf5c6873f85d0ed2faa729407f5abb194dc33380708c00315002febb6f1e1b484736bfcf9361ad366013a
   languageName: node
   linkType: hard
 
@@ -7481,10 +8698,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
+  dependencies:
+    min-indent: "npm:^1.0.0"
+  checksum: 10/18f045d57d9d0d90cd16f72b2313d6364fd2cb4bf85b9f593523ad431c8720011a4d5f08b6591c9d580f446e78855c5334a30fb91aa1560f5d9f95ed1b4a0530
+  languageName: node
+  linkType: hard
+
 "strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 10/492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
+  languageName: node
+  linkType: hard
+
+"strip-literal@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "strip-literal@npm:3.1.0"
+  dependencies:
+    js-tokens: "npm:^9.0.1"
+  checksum: 10/6eb00906a1c343a1050579d1d6023e067a2d72152edb92e64cad49535115beb2e77905ace24aa459f29b66e75edba75ef9d8eca90575b0322640d64a5d37e131
   languageName: node
   linkType: hard
 
@@ -7569,6 +8804,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"symbol-tree@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "symbol-tree@npm:3.2.4"
+  checksum: 10/c09a00aadf279d47d0c5c46ca3b6b2fbaeb45f0a184976d599637d412d3a70bbdc043ff33effe1206dea0e36e0ad226cb957112e7ce9a4bf2daedf7fa4f85c53
+  languageName: node
+  linkType: hard
+
 "synckit@npm:^0.9.1":
   version: 0.9.1
   resolution: "synckit@npm:0.9.1"
@@ -7643,6 +8885,69 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10/cfa1e1418e91289219501703c4693c70708c91ffb7f040fd318d24aef419fb5a43e0c0160df9471499191968b2451d8da7f8087b08c3133c251c40d24aced06c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10/b9d5fed3166fb1acd1e7f9a89afcd97ccbe18b9c1af0278e429455f6976d69271ba2d21797e7c36d57d6b05025e525d2882d88c2ab435b60d1ddf2fea361de57
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15":
+  version: 0.2.16
+  resolution: "tinyglobby@npm:0.2.16"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10/5c2c41b572ada38449e7c86a5fe034f204a1dbba577225a761a14f29f48dc3f2fc0d81a6c56fcc67c5a742cc3aa9fb5e2ca18dbf22b610b0bc0e549b34d5a0f8
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "tinypool@npm:1.1.1"
+  checksum: 10/0d54139e9dbc6ef33349768fa78890a4d708d16a7ab68e4e4ef3bb740609ddf0f9fd13292c2f413fbba756166c97051a657181c8f7ae92ade690604f183cc01d
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "tinyrainbow@npm:2.0.0"
+  checksum: 10/94d4e16246972614a5601eeb169ba94f1d49752426312d3cf8cc4f2cc663a2e354ffc653aa4de4eebccbf9eeebdd0caef52d1150271fdfde65d7ae7f3dcb9eb5
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^4.0.3":
+  version: 4.0.4
+  resolution: "tinyspy@npm:4.0.4"
+  checksum: 10/858a99e3ded2fba8fe7c243099d9e58e926d6525af03d19cdf86c1a9a30398161fb830b4f77890d266bcc1c69df08fa6f4baf29d089385e4cdaa98d7b6296e7c
+  languageName: node
+  linkType: hard
+
+"tldts-core@npm:^6.1.86":
+  version: 6.1.86
+  resolution: "tldts-core@npm:6.1.86"
+  checksum: 10/cb5dff9cc15661ac773a2099e98c99a5cb3cebc35909c23cc4261ff7992032c7501995ae995de3574dbbf3431e59c47496534d52f5e96abcb231f0e72144c020
+  languageName: node
+  linkType: hard
+
+"tldts@npm:^6.1.32":
+  version: 6.1.86
+  resolution: "tldts@npm:6.1.86"
+  dependencies:
+    tldts-core: "npm:^6.1.86"
+  bin:
+    tldts: bin/cli.js
+  checksum: 10/f7e66824e44479ccdda55ea556af14ce61c4d27708be403e3f90631defde49f82a580e1ca07187cc7e3b349e257a30c2808a22903f3a0548e136ebb609ccc109
+  languageName: node
+  linkType: hard
+
 "to-fast-properties@npm:^2.0.0":
   version: 2.0.0
   resolution: "to-fast-properties@npm:2.0.0"
@@ -7656,6 +8961,24 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10/10dda13571e1f5ad37546827e9b6d4252d2e0bc176c24a101252153ef435d83696e2557fe128c4678e4e78f5f01e83711c703eef9814eb12dab028580d45980a
+  languageName: node
+  linkType: hard
+
+"tough-cookie@npm:^5.1.1":
+  version: 5.1.2
+  resolution: "tough-cookie@npm:5.1.2"
+  dependencies:
+    tldts: "npm:^6.1.32"
+  checksum: 10/de430e6e6d34b794137e05b8ac2aa6b74ebbe6cdceb4126f168cf1e76101162a4b2e0e7587c3b70e728bd8654fc39958b2035be7619ee6f08e7257610ba4cd04
+  languageName: node
+  linkType: hard
+
+"tr46@npm:^5.1.0":
+  version: 5.1.1
+  resolution: "tr46@npm:5.1.1"
+  dependencies:
+    punycode: "npm:^2.3.1"
+  checksum: 10/833a0e1044574da5790148fd17866d4ddaea89e022de50279967bcd6b28b4ce0d30d59eb3acf9702b60918975b3bad481400337e3a2e6326cffa5c77b874753d
   languageName: node
   linkType: hard
 
@@ -7969,6 +9292,141 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-node@npm:3.2.4":
+  version: 3.2.4
+  resolution: "vite-node@npm:3.2.4"
+  dependencies:
+    cac: "npm:^6.7.14"
+    debug: "npm:^4.4.1"
+    es-module-lexer: "npm:^1.7.0"
+    pathe: "npm:^2.0.3"
+    vite: "npm:^5.0.0 || ^6.0.0 || ^7.0.0-0"
+  bin:
+    vite-node: vite-node.mjs
+  checksum: 10/343244ecabbab3b6e1a3065dabaeefa269965a7a7c54652d4b7a7207ee82185e887af97268c61755dcb2dd6a6ce5d9e114400cbd694229f38523e935703cc62f
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0":
+  version: 7.3.2
+  resolution: "vite@npm:7.3.2"
+  dependencies:
+    esbuild: "npm:^0.27.0"
+    fdir: "npm:^6.5.0"
+    fsevents: "npm:~2.3.3"
+    picomatch: "npm:^4.0.3"
+    postcss: "npm:^8.5.6"
+    rollup: "npm:^4.43.0"
+    tinyglobby: "npm:^0.2.15"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    lightningcss: ^1.21.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10/c5f7a9a60011c41c836cedf31c8ee7624102aff9b6a7f3aab2ff47639721bba0916f81994c3a3ea6577a16c4f0dfee1e7dbd244e0da8edd5954e3c6d48daaaa2
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "vitest@npm:3.2.4"
+  dependencies:
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/expect": "npm:3.2.4"
+    "@vitest/mocker": "npm:3.2.4"
+    "@vitest/pretty-format": "npm:^3.2.4"
+    "@vitest/runner": "npm:3.2.4"
+    "@vitest/snapshot": "npm:3.2.4"
+    "@vitest/spy": "npm:3.2.4"
+    "@vitest/utils": "npm:3.2.4"
+    chai: "npm:^5.2.0"
+    debug: "npm:^4.4.1"
+    expect-type: "npm:^1.2.1"
+    magic-string: "npm:^0.30.17"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.2"
+    std-env: "npm:^3.9.0"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^0.3.2"
+    tinyglobby: "npm:^0.2.14"
+    tinypool: "npm:^1.1.1"
+    tinyrainbow: "npm:^2.0.0"
+    vite: "npm:^5.0.0 || ^6.0.0 || ^7.0.0-0"
+    vite-node: "npm:3.2.4"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@types/debug": ^4.1.12
+    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+    "@vitest/browser": 3.2.4
+    "@vitest/ui": 3.2.4
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@types/debug":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: 10/f10bbce093ecab310ecbe484536ef4496fb9151510b2be0c5907c65f6d31482d9c851f3182531d1d27d558054aa78e8efd9d4702ba6c82058657e8b6a52507ee
+  languageName: node
+  linkType: hard
+
+"w3c-xmlserializer@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "w3c-xmlserializer@npm:5.0.0"
+  dependencies:
+    xml-name-validator: "npm:^5.0.0"
+  checksum: 10/d78f59e6b4f924aa53b6dfc56949959229cae7fe05ea9374eb38d11edcec01398b7f5d7a12576bd5acc57ff446abb5c9115cd83b9d882555015437cf858d42f0
+  languageName: node
+  linkType: hard
+
 "watchpack@npm:^2.4.1":
   version: 2.4.2
   resolution: "watchpack@npm:2.4.2"
@@ -7983,6 +9441,13 @@ __metadata:
   version: 3.0.1
   resolution: "webidl-conversions@npm:3.0.1"
   checksum: 10/b65b9f8d6854572a84a5c69615152b63371395f0c5dcd6729c45789052296df54314db2bc3e977df41705eacb8bc79c247cee139a63fa695192f95816ed528ad
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "webidl-conversions@npm:7.0.0"
+  checksum: 10/4c4f65472c010eddbe648c11b977d048dd96956a625f7f8b9d64e1b30c3c1f23ea1acfd654648426ce5c743c2108a5a757c0592f02902cf7367adb7d14e67721
   languageName: node
   linkType: hard
 
@@ -8027,6 +9492,32 @@ __metadata:
   bin:
     webpack: bin/webpack.js
   checksum: 10/a48bef7a511d826db7f9ebee2c84317214923ac40cb2aabe6a649546c54a76a55fc3b91ff03c05fed22a13a176891c47bbff7fcc644c53bcbe5091555863641b
+  languageName: node
+  linkType: hard
+
+"whatwg-encoding@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "whatwg-encoding@npm:3.1.1"
+  dependencies:
+    iconv-lite: "npm:0.6.3"
+  checksum: 10/bbef815eb67f91487c7f2ef96329743f5fd8357d7d62b1119237d25d41c7e452dff8197235b2d3c031365a17f61d3bb73ca49d0ed1582475aa4a670815e79534
+  languageName: node
+  linkType: hard
+
+"whatwg-mimetype@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "whatwg-mimetype@npm:4.0.0"
+  checksum: 10/894a618e2d90bf444b6f309f3ceb6e58cf21b2beaa00c8b333696958c4076f0c7b30b9d33413c9ffff7c5832a0a0c8569e5bb347ef44beded72aeefd0acd62e8
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^14.0.0, whatwg-url@npm:^14.1.1":
+  version: 14.2.0
+  resolution: "whatwg-url@npm:14.2.0"
+  dependencies:
+    tr46: "npm:^5.1.0"
+    webidl-conversions: "npm:^7.0.0"
+  checksum: 10/f0a95b0601c64f417c471536a2d828b4c16fe37c13662483a32f02f183ed0f441616609b0663fb791e524e8cd56d9a86dd7366b1fc5356048ccb09b576495e7c
   languageName: node
   linkType: hard
 
@@ -8149,6 +9640,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10/0de6e6cd8f2f94a8b5ca44e84cf1751eadcac3ebedcdc6e5fbbe6c8011904afcbc1a2777c53496ec02ced7b81f2e7eda61e76bf8262a8bc3ceaa1f6040508051
+  languageName: node
+  linkType: hard
+
 "word-wrap@npm:^1.2.5":
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
@@ -8186,6 +9689,35 @@ __metadata:
     string-width: "npm:^7.0.0"
     strip-ansi: "npm:^7.1.0"
   checksum: 10/b9d91564c091cf3978a7c18ca0f3e4d4606e83549dbe59cf76f5e77feefdd5ec91443155e8102630524d10a8c275efac8a7082c0f26fa43e6b989dc150d176ce
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.0":
+  version: 8.20.0
+  resolution: "ws@npm:8.20.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/b7ab934b21ffdea9f25a5af5097e8c1ec7625db553bca026c5a23e35b7c236f3fb89782f2b57fab9da553864512f9aa7d245827ef998d26ffa1b2187a19a6d10
+  languageName: node
+  linkType: hard
+
+"xml-name-validator@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "xml-name-validator@npm:5.0.0"
+  checksum: 10/43f30f3f6786e406dd665acf08cd742d5f8a46486bd72517edb04b27d1bcd1599664c2a4a99fc3f1e56a3194bff588b12f178b7972bc45c8047bdc4c3ac8d4a1
+  languageName: node
+  linkType: hard
+
+"xmlchars@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "xmlchars@npm:2.2.0"
+  checksum: 10/4ad5924974efd004a47cce6acf5c0269aee0e62f9a805a426db3337af7bcbd331099df174b024ace4fb18971b8a56de386d2e73a1c4b020e3abd63a4a9b917f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Refactor: side Flex 마이그레이션을 위한 테스트 추가 및 1유형 wrapper 전환

### 작업 내용
- `sipe.team`에 Vitest 기반 컴포넌트 테스트 환경을 추가했습니다.
- Flex 마이그레이션 대상 컴포넌트의 현재 렌더링 계약을 테스트로 고정했습니다.
- 단순 flex wrapper를 `@sipe-team/side`의 `Flex`로 전환하는 1유형 마이그레이션을 적용했습니다.

---

### 변경 사항
- 테스트 인프라 추가
  - Vitest, Testing Library 설정 추가
  - 마이그레이션 대상 컴포넌트 테스트 작성
- 1유형 마이그레이션 적용
  - `RecruitmentSummarySkeleton`
  - `People`
  - `Activity`
  - `ActivitiesSection`
  - `Card`
  - `RecruitBarChart`
- 기존 SCSS에서 중복된 flex wrapper 선언 정리

---

### 확인 사항
- [x] `corepack yarn test` 기준 테스트 통과
- [x] 기존 `sipe.team` 내 `@sipe-team/side` `Flex` 사용 방식과 동일한 방향으로 적용
- [x] 다른 유형들은 기존 SCSS 유지
