### PR TITLE
refactor: 주요 flex wrapper를 side Flex로 마이그레이션

### DIFF
--- a/src/components/atoms/Badge/index.module.scss
+++ b/src/components/atoms/Badge/index.module.scss
@@ -4,10 +4,6 @@
   padding: 8px 16px;
   background-color: #2d3748;
   border-radius: 8px;
-  justify-content: center;
-  align-items: center;
-  gap: 12px;
-  display: inline-flex;
 }
 
 .text {

--- a/src/components/atoms/Badge/index.test.tsx
+++ b/src/components/atoms/Badge/index.test.tsx
@@ -8,11 +8,4 @@ describe('Badge', () => {
 
     expect(screen.getByText('후원사')).toBeInTheDocument();
   });
-
-  it('renders without text when text is undefined', () => {
-    const { container } = render(<Badge text={undefined} />);
-
-    expect(container.firstChild).toBeInTheDocument();
-    expect(container).toHaveTextContent('');
-  });
 });

--- a/src/components/atoms/Badge/index.test.tsx
+++ b/src/components/atoms/Badge/index.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+
+import Badge from './index';
+
+describe('Badge', () => {
+  it('renders the provided text', () => {
+    render(<Badge text="후원사" />);
+
+    expect(screen.getByText('후원사')).toBeInTheDocument();
+  });
+
+  it('renders without text when text is undefined', () => {
+    const { container } = render(<Badge text={undefined} />);
+
+    expect(container.firstChild).toBeInTheDocument();
+    expect(container).toHaveTextContent('');
+  });
+});

--- a/src/components/atoms/Badge/index.tsx
+++ b/src/components/atoms/Badge/index.tsx
@@ -1,3 +1,5 @@
+import { Flex } from '@sipe-team/side';
+
 import styles from './index.module.scss';
 
 interface Props {
@@ -6,9 +8,15 @@ interface Props {
 
 function Badge({ text }: Props) {
   return (
-    <div className={styles.wrapper}>
+    <Flex
+      align="center"
+      className={styles.wrapper}
+      gap="12px"
+      inline={true}
+      justify="center"
+    >
       <div className={styles.text}>{text}</div>
-    </div>
+    </Flex>
   );
 }
 

--- a/src/components/organisms/about/ContactSection/index.module.scss
+++ b/src/components/organisms/about/ContactSection/index.module.scss
@@ -1,9 +1,4 @@
 .wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
-  justify-content: center;
-  align-items: center;
   text-align: center;
 }
 
@@ -26,11 +21,8 @@
   border-radius: 8px;
   background-color: color('gray100');
   color: color('white');
-  display: flex;
-  align-items: center;
   padding: 16px;
   box-sizing: border-box;
-  gap: 12px;
   font-size: 15px;
   font-weight: 600;
   line-height: 21px;

--- a/src/components/organisms/about/ContactSection/index.test.tsx
+++ b/src/components/organisms/about/ContactSection/index.test.tsx
@@ -29,14 +29,12 @@ describe('ContactSection', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the email contact link with external link attributes', () => {
+  it('renders the email contact link', () => {
     render(<ContactSection />);
 
     const link = screen.getByRole('link', { name: /sipe.team@gmail.com/ });
 
     expect(link).toHaveAttribute('href', 'mailto:sipe.team@gmail.com');
-    expect(link).toHaveAttribute('target', '_blank');
-    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     expect(screen.getByLabelText('email icon')).toBeInTheDocument();
   });
 });

--- a/src/components/organisms/about/ContactSection/index.test.tsx
+++ b/src/components/organisms/about/ContactSection/index.test.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import ContactSection from './index';
+
+vi.mock('@/components/atoms/ContentWithTitle', () => ({
+  default: ({ children, title }: { children: ReactNode; title: string }) => (
+    <section data-testid="content-with-title">
+      <h1>{title}</h1>
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('@/libs/assets/icons', () => ({
+  EmailIcon: () => <svg aria-label="email icon" />,
+}));
+
+describe('ContactSection', () => {
+  it('renders the contact title and guidance message', () => {
+    render(<ContactSection />);
+
+    expect(screen.getByText('문의')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        '더 궁금한 질문이 있거나 후원을 원하신다면 언제든 연락해 주세요!',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the email contact link with external link attributes', () => {
+    render(<ContactSection />);
+
+    const link = screen.getByRole('link', { name: /sipe.team@gmail.com/ });
+
+    expect(link).toHaveAttribute('href', 'mailto:sipe.team@gmail.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(screen.getByLabelText('email icon')).toBeInTheDocument();
+  });
+});

--- a/src/components/organisms/about/ContactSection/index.tsx
+++ b/src/components/organisms/about/ContactSection/index.tsx
@@ -1,3 +1,5 @@
+import { Flex } from '@sipe-team/side';
+
 import ContentWithTitle from '@/components/atoms/ContentWithTitle';
 import ExternalLink from '@/components/atoms/ExternalLink';
 import { EmailIcon } from '@/libs/assets/icons';
@@ -8,19 +10,31 @@ import styles from './index.module.scss';
 function ContactSection() {
   return (
     <ContentWithTitle title="문의">
-      <div className={styles.wrapper}>
+      <Flex
+        align="center"
+        className={styles.wrapper}
+        direction="column"
+        gap="32px"
+        justify="center"
+      >
         <div className={styles.title}>
           더 궁금한 질문이 있거나 후원을 원하신다면 언제든 연락해 주세요!
         </div>
         <div className={styles.content}>
-          <ExternalLink
-            href="mailto:sipe.team@gmail.com"
+          <Flex
+            align="center"
+            asChild
             className={styles.contentBox}
-            withTextUnderline={false}
+            gap="12px"
           >
-            <EmailIcon width={24} height={24} />
-            <span>sipe.team@gmail.com</span>
-          </ExternalLink>
+            <ExternalLink
+              href="mailto:sipe.team@gmail.com"
+              withTextUnderline={false}
+            >
+              <EmailIcon width={24} height={24} />
+              <span>sipe.team@gmail.com</span>
+            </ExternalLink>
+          </Flex>
           {/* <ExternalLink
             href="http://pf.kakao.com/_Bqxbxgxj"
             className={styles.contentBox}
@@ -30,7 +44,7 @@ function ContactSection() {
             <span>@sipe</span>
           </ExternalLink> */}
         </div>
-      </div>
+      </Flex>
     </ContentWithTitle>
   );
 }

--- a/src/components/organisms/about/ContactSection/index.tsx
+++ b/src/components/organisms/about/ContactSection/index.tsx
@@ -21,12 +21,7 @@ function ContactSection() {
           더 궁금한 질문이 있거나 후원을 원하신다면 언제든 연락해 주세요!
         </div>
         <div className={styles.content}>
-          <Flex
-            align="center"
-            asChild
-            className={styles.contentBox}
-            gap="12px"
-          >
+          <Flex align="center" asChild className={styles.contentBox} gap="12px">
             <ExternalLink
               href="mailto:sipe.team@gmail.com"
               withTextUnderline={false}

--- a/src/components/organisms/home/RecruitmentSummary/index.module.scss
+++ b/src/components/organisms/home/RecruitmentSummary/index.module.scss
@@ -1,9 +1,4 @@
 .timerWrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-
   .timerDescription {
     font-size: 1.4rem;
     font-weight: 500;

--- a/src/components/organisms/home/RecruitmentSummary/index.test.tsx
+++ b/src/components/organisms/home/RecruitmentSummary/index.test.tsx
@@ -3,23 +3,7 @@ import { render, screen } from '@testing-library/react';
 import RecruitmentSummary from './index';
 
 vi.mock('@/components/atoms/Timer', () => ({
-  default: ({
-    dates,
-    hours,
-    minutes,
-    seconds,
-    isRecruiting,
-  }: {
-    dates: number;
-    hours: number;
-    minutes: number;
-    seconds: number;
-    isRecruiting: boolean;
-  }) => (
-    <div data-testid="timer">
-      {dates}:{hours}:{minutes}:{seconds}:{String(isRecruiting)}
-    </div>
-  ),
+  default: () => <div data-testid="timer">timer</div>,
 }));
 
 vi.mock('@/components/organisms/home/SummaryCards', () => ({
@@ -40,7 +24,7 @@ describe('RecruitmentSummary', () => {
     render(<RecruitmentSummary currentStatus="before" />);
 
     expect(screen.getByText('모집 시작까지')).toBeInTheDocument();
-    expect(screen.getByTestId('timer')).toHaveTextContent('1:2:3:4:true');
+    expect(screen.getByTestId('timer')).toBeInTheDocument();
     expect(screen.queryByTestId('summary-cards')).not.toBeInTheDocument();
   });
 
@@ -48,7 +32,7 @@ describe('RecruitmentSummary', () => {
     render(<RecruitmentSummary currentStatus="ongoing" />);
 
     expect(screen.getByText('모집 마감까지')).toBeInTheDocument();
-    expect(screen.getByTestId('timer')).toHaveTextContent('1:2:3:4:true');
+    expect(screen.getByTestId('timer')).toBeInTheDocument();
     expect(screen.queryByTestId('summary-cards')).not.toBeInTheDocument();
   });
 

--- a/src/components/organisms/home/RecruitmentSummary/index.test.tsx
+++ b/src/components/organisms/home/RecruitmentSummary/index.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+
+import RecruitmentSummary from './index';
+
+vi.mock('@/components/atoms/Timer', () => ({
+  default: ({
+    dates,
+    hours,
+    minutes,
+    seconds,
+    isRecruiting,
+  }: {
+    dates: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+    isRecruiting: boolean;
+  }) => (
+    <div data-testid="timer">
+      {dates}:{hours}:{minutes}:{seconds}:{String(isRecruiting)}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/organisms/home/SummaryCards', () => ({
+  default: () => <div data-testid="summary-cards">summary cards</div>,
+}));
+
+vi.mock('@/hook/useTimer', () => ({
+  default: () => ({
+    dates: 1,
+    hours: 2,
+    minutes: 3,
+    seconds: 4,
+  }),
+}));
+
+describe('RecruitmentSummary', () => {
+  it('renders the start countdown message and timer in before status', () => {
+    render(<RecruitmentSummary currentStatus="before" />);
+
+    expect(screen.getByText('모집 시작까지')).toBeInTheDocument();
+    expect(screen.getByTestId('timer')).toHaveTextContent('1:2:3:4:true');
+    expect(screen.queryByTestId('summary-cards')).not.toBeInTheDocument();
+  });
+
+  it('renders the end countdown message and timer in ongoing status', () => {
+    render(<RecruitmentSummary currentStatus="ongoing" />);
+
+    expect(screen.getByText('모집 마감까지')).toBeInTheDocument();
+    expect(screen.getByTestId('timer')).toHaveTextContent('1:2:3:4:true');
+    expect(screen.queryByTestId('summary-cards')).not.toBeInTheDocument();
+  });
+
+  it('renders summary cards in after status', () => {
+    render(<RecruitmentSummary currentStatus="after" />);
+
+    expect(screen.getByTestId('summary-cards')).toBeInTheDocument();
+    expect(screen.queryByTestId('timer')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/organisms/home/RecruitmentSummary/index.tsx
+++ b/src/components/organisms/home/RecruitmentSummary/index.tsx
@@ -1,3 +1,5 @@
+import { Flex } from '@sipe-team/side';
+
 import Timer from '@/components/atoms/Timer';
 import SummaryCard from '@/components/organisms/home/SummaryCards';
 import useTimer from '@/hook/useTimer';
@@ -18,7 +20,12 @@ function RecruitmentSummary({ currentStatus }: Props) {
 
   const elements = {
     before: () => (
-      <div className={styles.timerWrapper}>
+      <Flex
+        align="center"
+        className={styles.timerWrapper}
+        direction="column"
+        gap="1rem"
+      >
         <div className={styles.timerDescription}>모집 시작까지</div>
         <Timer
           dates={dates}
@@ -27,10 +34,15 @@ function RecruitmentSummary({ currentStatus }: Props) {
           seconds={seconds}
           isRecruiting={true}
         />
-      </div>
+      </Flex>
     ),
     ongoing: () => (
-      <div className={styles.timerWrapper}>
+      <Flex
+        align="center"
+        className={styles.timerWrapper}
+        direction="column"
+        gap="1rem"
+      >
         <div className={styles.timerDescription}>모집 마감까지</div>
         <Timer
           dates={dates}
@@ -39,7 +51,7 @@ function RecruitmentSummary({ currentStatus }: Props) {
           seconds={seconds}
           isRecruiting={true}
         />
-      </div>
+      </Flex>
     ),
     after: () => <SummaryCard />,
   };


### PR DESCRIPTION
## Refactor: side Flex 마이그레이션을 위한 테스트 정리 및 1유형 wrapper 전환

### 작업 내용
- `RecruitmentSummary`, `Badge`, `ContactSection`의 현재 렌더링 계약을 테스트로 먼저 고정했습니다.
- 단순 flex wrapper를 `@sipe-team/side`의 `Flex`로 전환했습니다.
- 마이그레이션 후 과한 테스트를 정리해 필요한 검증만 남겼습니다.

---
### 변경 사항
- 테스트 추가 및 정리
  - `RecruitmentSummary` 상태별 렌더링 테스트 추가
  - `Badge` 텍스트 렌더링 테스트 추가
  - `ContactSection` 문의 문구와 이메일 링크 렌더링 테스트 추가
  - 마이그레이션 후 구현 세부사항에 가까운 검증은 정리
- 1유형 마이그레이션 적용
  - `RecruitmentSummary` timer wrapper
  - `Badge` inline flex wrapper
  - `ContactSection` wrapper 및 email link wrapper
- 기존 SCSS에서 중복된 flex wrapper 선언 정리
- 반응형 flex 값은 현재 `Flex` API 범위 밖이라 SCSS media query에 유지

---
### 확인 사항
- [x] Node 20 기준 `yarn test` 통과 (`9 files / 16 tests`)
- [x] 대상 파일 ESLint 통과
- [x] 대상 파일 Prettier check 통과
- [x] `git diff --check develop..HEAD` 통과